### PR TITLE
docs: declare project authorship in CITATION.cff and AUTHORS

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -1,0 +1,8 @@
+# Authors of Unit Test Skills, listed alphabetically by family name.
+# See CITATION.cff for structured metadata, and the repository's
+# contributor graph for the full commit history.
+
+Maks Danylenko <max.danylenko@clear-solutions.ltd> (@MaksDanylenko)
+Anastasiia Mudra <nastja.mudra@gmail.com> (@anesmy)
+
+Built and maintained at Mavka AI <https://mavka.ai/>.

--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,29 @@
+cff-version: 1.2.0
+title: Unit Test Skills
+message: >-
+  If you use these skills in your work, please cite them
+  using the metadata from this file.
+type: software
+abstract: >-
+  A collection of AI agent skills for generating high-quality
+  unit tests, encoding battle-tested testing principles that
+  work across any programming language.
+authors:
+  - given-names: Maks
+    family-names: Danylenko
+    alias: MaksDanylenko
+    affiliation: Mavka AI
+  - given-names: Anastasiia
+    family-names: Mudra
+    alias: anesmy
+    affiliation: Mavka AI
+  - name: Mavka AI
+    website: 'https://mavka.ai/'
+repository-code: 'https://github.com/mavka-ai/unit-tests-skills'
+url: 'https://mavka.ai/'
+keywords:
+  - unit-testing
+  - ai-agents
+  - claude-code
+  - agent-skills
+  - test-generation


### PR DESCRIPTION
Records project authorship explicitly, since GitHub has no repo-level "author" field — only the org as owner and the contributor graph.

## Changes

- **`CITATION.cff`** — GitHub renders this natively as a "Cite this repository" button in the sidebar. Lists both of us as person authors plus Mavka AI as an entity author. Validated against CFF schema 1.2.0 (`cffconvert --validate` → *"Citation metadata are valid according to schema version 1.2.0"*).
- **`AUTHORS`** — plain-text convention file with the same two names and GitHub handles.

## Notes

- **Ordering** is alphabetical by family name (Danylenko, Mudra), not by seniority or commit count — contributions are 7 commits each, so no ordering is "earned" and alphabetical is the neutral rule. Happy to switch to chronological (@anesmy first, as author of the initial commit) if you prefer.
- Related fix, no code change needed: my 7 commits were previously unattributed because `max.danylenko@clear-solutions.ltd` was not linked to a GitHub account. That email is now added to @MaksDanylenko, so GitHub has retroactively linked them and the contributor graph shows both of us at 7.
- The repo still has **no LICENSE**, so all rights are reserved by default and the installation instructions in the README arguably conflict with that. Worth a separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)