### PR TITLE
fix(traffic): make the 403 diagnostics name the actual cause

### DIFF
--- a/.github/workflows/traffic-stats.yml
+++ b/.github/workflows/traffic-stats.yml
@@ -50,9 +50,13 @@ jobs:
 
       - name: Fetch traffic data from the GitHub API
         env:
-          # A classic PAT with `repo` scope can be supplied as the TRAFFIC_TOKEN
-          # secret. Otherwise the job's own GITHUB_TOKEN is used, which works as
-          # long as the workflow keeps `contents: write`.
+          # The traffic endpoints are not reachable with GITHUB_TOKEN at all —
+          # it is a GitHub App installation token, and no `permissions:` block
+          # grants it access ("Resource not accessible by integration"). A PAT
+          # in the TRAFFIC_TOKEN secret is therefore required:
+          #   - fine-grained: Administration -> Read-only on this repository
+          #   - classic:      `repo` scope
+          # Only read access is needed here; the push below uses GITHUB_TOKEN.
           GH_TOKEN: ${{ secrets.TRAFFIC_TOKEN || github.token }}
         run: |
           set -euo pipefail
@@ -62,8 +66,10 @@ jobs:
             local endpoint="$1" out="$2"
             if ! gh api -H "Accept: application/vnd.github+json" \
                  "repos/${GITHUB_REPOSITORY}/${endpoint}" > "${out}" 2>/tmp/traffic/err.txt; then
-              echo "::error::Failed to read ${endpoint}. The traffic API requires push access."
-              echo "::error::If this is a 403, add a classic PAT with 'repo' scope as the TRAFFIC_TOKEN secret."
+              echo "::error::Failed to read ${endpoint}."
+              echo "::error::403 'not accessible by integration' -> GITHUB_TOKEN can never read traffic; set the TRAFFIC_TOKEN secret."
+              echo "::error::403 'not accessible by personal access token' -> TRAFFIC_TOKEN lacks Administration: Read-only on this repository."
+              echo "::error::Fine-grained PATs also need org approval when the organisation requires it."
               cat /tmp/traffic/err.txt >&2
               return 1
             fi


### PR DESCRIPTION
## Why

Bringing the traffic workflow up hit both possible 403s, and the old error message pointed at the wrong fix for one of them.

| Run | Token | API response |
|---|---|---|
| [32141567248](https://github.com/mavka-ai/unit-tests-skills/actions/runs/32141567248) | `GITHUB_TOKEN` | `Resource not accessible by integration` |
| [32143711182](https://github.com/mavka-ai/unit-tests-skills/actions/runs/32143711182) | fine-grained PAT | `Resource not accessible by personal access token` |

Two conclusions:

1. **`GITHUB_TOKEN` can never read the traffic endpoints.** It is a GitHub App installation token, and no `permissions:` block grants access. The previous comment implied `contents: write` would be sufficient — it is not. A PAT is mandatory, not a fallback.
2. **A fine-grained PAT fails with a different message when it lacks the scope.** The required permission is `Administration -> Read-only`. The old message mentioned only classic PATs, so it gave no hint about this.

## What changed

The two 403 bodies are now mapped to their respective fixes, plus org approval as a third possibility:

```
::error::403 'not accessible by integration' -> GITHUB_TOKEN can never read traffic; set the TRAFFIC_TOKEN secret.
::error::403 'not accessible by personal access token' -> TRAFFIC_TOKEN lacks Administration: Read-only on this repository.
::error::Fine-grained PATs also need org approval when the organisation requires it.
```

The `env:` comment now records that read access is all the PAT needs — the push step authenticates with `GITHUB_TOKEN` through the credentials `actions/checkout` persists, which is enough for the unprotected `traffic-data` branch.

No behaviour change: same endpoints, same merge logic. Documentation and error text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
