### PR TITLE
feat: distribute as a Claude Code plugin

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -11,7 +11,6 @@
       "source": "./",
       "displayName": "Unit Test Skills",
       "description": "Generate high-quality unit tests. Analyzes code, produces a reviewable Given-When-Then test case list, then writes the tests and verifies they compile and pass. Java support covers JUnit 5, Mockito, and AssertJ.",
-      "version": "1.0.0",
       "author": {
         "name": "Mavka",
         "url": "https://mavka.ai/"

--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -1,0 +1,35 @@
+{
+  "name": "mavka",
+  "description": "Skills from Mavka for writing and maintaining high-quality tests with AI coding agents.",
+  "owner": {
+    "name": "Mavka",
+    "url": "https://mavka.ai/"
+  },
+  "plugins": [
+    {
+      "name": "unit-tests-skills",
+      "source": "./",
+      "displayName": "Unit Test Skills",
+      "description": "Generate high-quality unit tests. Analyzes code, produces a reviewable Given-When-Then test case list, then writes the tests and verifies they compile and pass. Java support covers JUnit 5, Mockito, and AssertJ.",
+      "version": "1.0.0",
+      "author": {
+        "name": "Mavka",
+        "url": "https://mavka.ai/"
+      },
+      "homepage": "https://mavka.ai/",
+      "repository": "https://github.com/mavka-ai/unit-tests-skills",
+      "license": "MIT",
+      "category": "testing",
+      "keywords": [
+        "unit-testing",
+        "test-generation",
+        "tdd",
+        "java",
+        "junit5",
+        "mockito",
+        "assertj",
+        "code-quality"
+      ]
+    }
+  ]
+}

--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,0 +1,23 @@
+{
+  "name": "unit-tests-skills",
+  "displayName": "Unit Test Skills",
+  "description": "Generate high-quality unit tests. Analyzes code, produces a reviewable Given-When-Then test case list, then writes the tests and verifies they compile and pass. Java support covers JUnit 5, Mockito, and AssertJ.",
+  "version": "1.0.0",
+  "author": {
+    "name": "Mavka",
+    "url": "https://mavka.ai/"
+  },
+  "homepage": "https://mavka.ai/",
+  "repository": "https://github.com/mavka-ai/unit-tests-skills",
+  "license": "MIT",
+  "keywords": [
+    "unit-testing",
+    "test-generation",
+    "tdd",
+    "java",
+    "junit5",
+    "mockito",
+    "assertj",
+    "code-quality"
+  ]
+}

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -1,0 +1,48 @@
+name: Validate Plugin
+
+# The community-marketplace review pipeline runs `claude plugin validate` on
+# every submission, so this catches a rejection before it happens rather than
+# after. Validation is local and needs no credentials.
+
+on:
+  pull_request:
+    paths:
+      - '.claude-plugin/**'
+      - 'skills/**'
+      - 'scripts/validate-plugin.sh'
+      - '.github/workflows/validate-plugin.yml'
+  push:
+    branches: [main]
+    paths:
+      - '.claude-plugin/**'
+      - 'skills/**'
+      - 'scripts/validate-plugin.sh'
+      - '.github/workflows/validate-plugin.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    name: claude plugin validate --strict
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      - name: Install Claude Code CLI
+        # Deliberately unpinned. The review pipeline validates against whatever
+        # version is current, so pinning here would let this job pass while a
+        # submission fails on a check added upstream. The cost is that a new
+        # release can break this job — which is the signal we want.
+        run: npm install -g @anthropic-ai/claude-code
+
+      - name: Validate plugin and marketplace manifests
+        run: ./scripts/validate-plugin.sh

--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -44,5 +44,11 @@ jobs:
         # release can break this job — which is the signal we want.
         run: npm install -g @anthropic-ai/claude-code
 
+      - name: Verify the CLI is runnable
+        # A global npm install can leave the native binary missing when
+        # postinstall is skipped. Surface that as its own failed step rather
+        # than as a confusing error inside validation.
+        run: claude --version
+
       - name: Validate plugin and marketplace manifests
         run: ./scripts/validate-plugin.sh

--- a/.gitignore
+++ b/.gitignore
@@ -34,3 +34,5 @@ build/
 
 mvnw*
 .mvn/
+### Runtime logs ###
+logs/

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,40 @@ Rules are inside each skill folder:
 - `generate-test-cases/rules/general/` — general rules only
 - `generate-tests/rules/tests/` — all rules (general, java, post-generation)
 
+## Plugin Validation
+
+This repository doubles as a Claude Code plugin **and** a marketplace, declared
+in `.claude-plugin/`. Both manifests must stay valid, because the
+community-marketplace review pipeline runs `claude plugin validate` on every
+submission.
+
+**After changing anything under `.claude-plugin/` or `skills/`, run:**
+
+```bash
+./scripts/validate-plugin.sh
+```
+
+CI runs the same script on every pull request touching those paths
+(`.github/workflows/validate-plugin.yml`). No credentials are needed —
+validation is entirely local.
+
+### What it checks, and why each check exists
+
+| Check | Why it is not redundant |
+|---|---|
+| `claude plugin validate . --strict` | Validates the marketplace manifest. `--strict` promotes warnings to errors, which matters because the CLI reports a `version` that disagrees between the entry and `plugin.json` as a *warning* — while `plugin.json` silently wins at install time. |
+| `claude plugin validate <copy> --strict` | The validator switches to marketplace mode the moment it sees `marketplace.json`, so validating the repo root **never** exercises `plugin.json`'s own schema. The script copies the plugin without the marketplace file to force plugin mode. |
+| Entry name matches `plugin.json` | The CLI does **not** check this. A marketplace entry naming a plugin that `plugin.json` does not define validates cleanly and only fails later at install time with `Plugin "<name>" not found in marketplace`. Verified against claude 2.1.235. |
+
+### Conventions that follow from this
+
+- Declare `version` in `plugin.json` **only**. Repeating it in the marketplace
+  entry adds a way for the two to drift, and the entry's copy is ignored.
+- The plugin `name` is immutable once published — it is the install id and the
+  skill namespace (`/unit-tests-skills:generate-tests`). Do not rename it.
+- Keep `skills/` at the repository root. Only `plugin.json` and
+  `marketplace.json` belong inside `.claude-plugin/`.
+
 ## Creating a New Skill
 
 ### Directory Structure

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -54,6 +54,32 @@ Key rule topics:
 - **Java specifics** — JUnit 5 + Mockito + AssertJ; `@SpringBootTest` is FORBIDDEN in unit tests; use `ArgumentCaptor` to verify DTO/model fields; use `any()` only for irrelevant arguments; `@WebMvcTest` for controllers (`controller-test-rules.md`)
 - **Post-generation verification** — compilation verification (`compilation-verification.md`) AND test execution verification (`test-execution-verification.md`) — tests must both compile and pass
 
+## Plugin Distribution
+
+This repository is also a Claude Code plugin and marketplace, declared in
+`.claude-plugin/`. Users install it with:
+
+```
+/plugin marketplace add mavka-ai/unit-tests-skills
+/plugin install unit-tests-skills@mavka
+```
+
+**Any change to `.claude-plugin/` or `skills/` must be validated before pushing:**
+
+```bash
+./scripts/validate-plugin.sh
+```
+
+CI enforces this on every PR touching those paths, and the community-marketplace
+review pipeline runs the same `claude plugin validate` check — a failure here is
+a rejected submission there.
+
+Three non-obvious rules apply: validating the repo root does not validate
+`plugin.json`, a mismatched entry name passes validation but breaks installs,
+and `version` belongs in `plugin.json` only. See
+[AGENTS.md](AGENTS.md#plugin-validation) for the reasoning behind each — that
+file is the single source of truth; do not duplicate its detail here.
+
 ## Contributing
 
 - Place general rules in `rules/general/` (or `rules/tests/general/` for generate-tests)

--- a/README.md
+++ b/README.md
@@ -20,7 +20,18 @@
 
 **unit-tests-skills** is a collection of AI agent skills for generating high-quality unit tests. These skills encode battle-tested testing principles that work across any programming language.
 
-### Option 1: Using openskills (Recommended)
+### Option 1: Claude Code plugin (Recommended for Claude Code)
+
+```
+/plugin marketplace add mavka-ai/unit-tests-skills
+/plugin install unit-tests-skills@mavka
+```
+
+Skills are namespaced by the plugin, so they are invoked as
+`/unit-tests-skills:generate-tests` and `/unit-tests-skills:generate-test-cases`.
+Update later with `/plugin marketplace update mavka`.
+
+### Option 2: Using openskills (Recommended for other agents)
 
 [openskills](https://github.com/numman-ali/openskills) automatically generates `AGENTS.md` for maximum AI agent effectiveness.
 
@@ -34,7 +45,7 @@ npx openskills sync
 
 **Why openskills?** According to [Vercel's research](https://vercel.com/blog/agents-md-outperforms-skills-in-our-agent-evals), skills alone trigger only 53% of the time. With `AGENTS.md`, success rate jumps to **100%**.
 
-### Option 2: Using npx skills
+### Option 3: Using npx skills
 
 ```bash
 npx skills add mavka-ai/unit-tests-skills

--- a/scripts/validate-plugin.sh
+++ b/scripts/validate-plugin.sh
@@ -1,0 +1,79 @@
+#!/usr/bin/env bash
+#
+# Validates the Claude Code plugin and marketplace manifests.
+#
+# Run before pushing any change to .claude-plugin/ or skills/. The
+# community-marketplace review pipeline runs `claude plugin validate` on every
+# submission, so a failure here is a failure there.
+#
+# Usage: ./scripts/validate-plugin.sh
+# Requires: claude (npm i -g @anthropic-ai/claude-code), jq
+#
+# No credentials needed — validation is entirely local.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT}"
+
+MARKETPLACE=".claude-plugin/marketplace.json"
+PLUGIN=".claude-plugin/plugin.json"
+
+for f in "${MARKETPLACE}" "${PLUGIN}"; do
+  [ -f "${f}" ] || { echo "✘ missing ${f}"; exit 1; }
+done
+
+command -v claude >/dev/null 2>&1 \
+  || { echo "✘ claude CLI not found. Install: npm i -g @anthropic-ai/claude-code"; exit 1; }
+command -v jq >/dev/null 2>&1 \
+  || { echo "✘ jq not found"; exit 1; }
+
+echo "claude $(claude --version)"
+echo
+
+# --- 1. Marketplace manifest -------------------------------------------------
+# --strict promotes warnings to errors. Worth it: the CLI reports a real defect
+# as a mere warning — a marketplace entry whose `version` disagrees with
+# plugin.json, where plugin.json silently wins — and that is exactly the kind
+# of drift that ships a marketplace advertising a version nobody receives.
+echo "==> Marketplace manifest"
+claude plugin validate . --strict
+
+# --- 2. Plugin manifest, in isolation ---------------------------------------
+# The validator switches to marketplace mode as soon as it sees
+# marketplace.json, so validating the repo root never exercises plugin.json's
+# own schema. Copy the plugin without the marketplace file to force plugin mode.
+echo
+echo "==> Plugin manifest (isolated)"
+WORK="$(mktemp -d)"
+trap 'rm -rf "${WORK}"' EXIT
+
+cp -R .claude-plugin "${WORK}/"
+rm -f "${WORK}/.claude-plugin/marketplace.json"
+for d in skills commands agents hooks; do
+  [ -d "${d}" ] && cp -R "${d}" "${WORK}/"
+done
+claude plugin validate "${WORK}" --strict
+
+# --- 3. Entry name must match the plugin ------------------------------------
+# The CLI does NOT check this: a marketplace entry named something plugin.json
+# does not define passes validation cleanly, and only fails later at install
+# time with "Plugin <name> not found in marketplace". Verified against
+# claude 2.1.235.
+echo
+echo "==> Entry name matches plugin.json"
+PLUGIN_NAME="$(jq -r '.name' "${PLUGIN}")"
+MARKETPLACE_NAME="$(jq -r '.name' "${MARKETPLACE}")"
+
+if ! jq -e --arg n "${PLUGIN_NAME}" \
+     '[.plugins[].name] | index($n) != null' "${MARKETPLACE}" >/dev/null; then
+  echo "✘ ${MARKETPLACE} has no entry named \"${PLUGIN_NAME}\""
+  echo "  plugin.json declares:  ${PLUGIN_NAME}"
+  echo "  marketplace entries:   $(jq -r '[.plugins[].name] | join(", ")' "${MARKETPLACE}")"
+  echo "  Installs would fail with: Plugin \"${PLUGIN_NAME}\" not found in marketplace."
+  exit 1
+fi
+echo "✔ installs as ${PLUGIN_NAME}@${MARKETPLACE_NAME}"
+
+echo
+echo "✔ All plugin validation passed"

--- a/scripts/validate-plugin.sh
+++ b/scripts/validate-plugin.sh
@@ -28,7 +28,17 @@ command -v claude >/dev/null 2>&1 \
 command -v jq >/dev/null 2>&1 \
   || { echo "✘ jq not found"; exit 1; }
 
-echo "claude $(claude --version)"
+# A global npm install can leave the native binary missing when postinstall is
+# skipped (--ignore-scripts, --omit=optional, some pnpm configs). The CLI is then
+# on PATH but every invocation errors, so check it is runnable before trusting it.
+if ! CLAUDE_VERSION="$(claude --version 2>&1)"; then
+  echo "✘ claude is on PATH but not runnable:"
+  printf '%s\n' "${CLAUDE_VERSION}" | sed 's/^/    /'
+  echo "  Complete the install with:"
+  echo "    node \"\$(npm root -g)/@anthropic-ai/claude-code/install.cjs\""
+  exit 1
+fi
+echo "claude ${CLAUDE_VERSION}"
 echo
 
 # --- 1. Marketplace manifest -------------------------------------------------


### PR DESCRIPTION
## Why

The skills could only be installed through `npx`. That leaves out Claude Code's own distribution path, and being a plugin is a prerequisite for submitting to the [official Anthropic plugin directory](https://clau.de/plugin-directory-submission).

After this, installation is two commands with no external tooling:

```
/plugin marketplace add mavka-ai/unit-tests-skills
/plugin install unit-tests-skills@mavka
```

## What changed

- **`.claude-plugin/plugin.json`** — the plugin manifest.
- **`.claude-plugin/marketplace.json`** — the catalog, so this repo *is* a marketplace. No approval needed; it works the moment this merges.
- **`README.md`** — plugin install is now Option 1; openskills and npx move to 2 and 3.

**No files moved.** The repository root doubles as the plugin, because `skills/` already sits exactly where the plugin format expects it, so the marketplace entry uses `"./"` as its source.

## Naming

Both names are public-facing and the plugin name is immutable once published, so they are worth stating explicitly:

- **Marketplace `mavka`**, not `unit-tests-skills`. `java-tests-skills`, `code-review-skills` and the rest can be listed in this same catalog later, and users keep one name they already recognise. It is also not on Anthropic's reserved-names list.
- **Plugin `unit-tests-skills`**, matching the repository exactly. Shorter names were tempting, but a name that mismatches the repo people arrived from costs more than the characters saved.

One consequence worth knowing: plugin skills are namespaced, so invocation becomes `/unit-tests-skills:generate-tests` rather than `/generate-tests`. Users installing via openskills or npx are unaffected.

## Verification

Run against Claude Code 2.1.235.

```
$ claude plugin validate .
✔ Validation passed

$ claude plugin install unit-tests-skills@mavka
✔ Successfully installed plugin: unit-tests-skills@mavka (scope: user)

$ claude plugin details unit-tests-skills
Component inventory
  Skills (2)  generate-test-cases, generate-tests
Projected token cost
  Always-on:   ~157 tok   added to every session
```

The first validation run warned about a missing marketplace `description`; it was added and the rerun is clean. The test marketplace and plugin were uninstalled afterwards, so nothing local points at a working copy.

## After merging

Submit to the official directory at https://clau.de/plugin-directory-submission — review takes a few days, and the plugin distributes from this repo in the meantime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
