### PR TITLE
docs: show the namespaced command form for plugin installs

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,12 +78,20 @@ npx skills add mavka-ai/unit-tests-skills -a claude-code
 
 ## Available Skills
 
-| Skill | Command | Description |
-|-------|---------|-------------|
-| Generate Tests | `/generate-tests <target>` | Full workflow: analyzes code, outputs test cases for review, then generates test code. Supports Java (JUnit 5, Mockito, AssertJ). |
-| Generate Test Cases | `/generate-test-cases <target>` | Analysis only: outputs a structured list of test cases in Given-When-Then format without generating code. |
+| Skill | Command | Plugin command | Description |
+|-------|---------|----------------|-------------|
+| Generate Tests | `/generate-tests <target>` | `/unit-tests-skills:generate-tests <target>` | Full workflow: analyzes code, outputs test cases for review, then generates test code. Supports Java (JUnit 5, Mockito, AssertJ). |
+| Generate Test Cases | `/generate-test-cases <target>` | `/unit-tests-skills:generate-test-cases <target>` | Analysis only: outputs a structured list of test cases in Given-When-Then format without generating code. |
+
+Claude Code namespaces plugin skills by plugin name, so the command depends on
+how you installed. Use the **Plugin command** after
+[Option 1](#option-1-claude-code-plugin-recommended-for-claude-code); use the
+plain **Command** after openskills or `npx skills`.
 
 ## Usage
+
+> Examples below use the plain command form. If you installed as a plugin,
+> prefix the skill name with the plugin: `/unit-tests-skills:generate-tests`.
 
 ### Generate Tests (Primary Skill)
 


### PR DESCRIPTION
## The problem

The README recommends the Claude Code plugin as **Option 1**, and then every usage example shows:

```
/generate-tests src/services/OrderService.java
```

That is exactly the form that **does not work** after a plugin install. Claude Code namespaces plugin skills by plugin name, so the working command is `/unit-tests-skills:generate-tests`. Anyone following the recommended install path hit an unknown command on their first try.

Option 1 did mention the namespacing, but only in passing, three sections above the examples that contradict it.

## The fix

**Available Skills** now lists both forms side by side, so the difference is visible at the point where someone looks up the command:

| Skill | Command | Plugin command |
|---|---|---|
| Generate Tests | `/generate-tests <target>` | `/unit-tests-skills:generate-tests <target>` |
| Generate Test Cases | `/generate-test-cases <target>` | `/unit-tests-skills:generate-test-cases <target>` |

…followed by one line on which form goes with which install method, linking back to Option 1.

**Usage** states up front that its examples use the plain form and how to adapt them.

## Verification

The new internal anchor was checked against the actual headings rather than assumed:

```
internal anchors used: ['option-1-claude-code-plugin-recommended-for-claude-code']
BROKEN: none ✔
```

Docs only — no manifest or skill changes, so the plugin validation workflow does not apply to this diff.

## Noted, not changed

Option 3 still carries a "For Claude Code specifically" subsection for `npx skills add -a claude-code`, which reads oddly now that Option 1 is the Claude Code route. It is accurate, just awkwardly placed — left alone to keep this diff to the actual defect.