### PR TITLE
feat: add Java integration test rules for infrastructure-backed code

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,7 +18,7 @@ Skills for generating unit tests with consistent quality. Each skill is self-con
 Rules are inside each skill folder:
 
 - `generate-test-cases/rules/general/` — general rules only
-- `generate-tests/rules/tests/` — all rules (general, java, post-generation)
+- `generate-tests/rules/tests/` — all rules (general, java unit and integration, post-generation)
 
 ## Plugin Validation
 
@@ -106,6 +106,8 @@ skills/{skill-name}/rules/
   general/
     {rule-name}.md
   {language}/unit/
+    {rule-name}.md
+  {language}/integration/
     {rule-name}.md
 ```
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ skills/
     rules/tests/
       general/            # General testing rules (superset of generate-test-cases rules)
       java/unit/          # Java-specific rules (JUnit 5, Mockito, AssertJ)
+      java/integration/   # Integration rules (Testcontainers, WireMock, LocalStack)
       post-generation/    # Compilation verification rules
 templates/
   AGENTS-SNIPPET.md       # Template users copy into their project's AGENTS.md
@@ -83,7 +84,7 @@ file is the single source of truth; do not duplicate its detail here.
 ## Contributing
 
 - Place general rules in `rules/general/` (or `rules/tests/general/` for generate-tests)
-- Place language-specific rules in `rules/tests/{language}/unit/`
+- Place language-specific rules in `rules/tests/{language}/unit/`, or `rules/tests/{language}/integration/` when the rule needs real infrastructure (a container, a stub server) rather than mocks
 - **Keep general rules in sync**: General rules exist in TWO locations (`generate-test-cases/rules/general/` and `generate-tests/rules/tests/general/`). When adding or updating a general rule, copy the change to both directories
 - When adding a new rule, also add it to the Rules Reference list in the relevant `SKILL.md` file(s)
 - All changes require a PR with CODEOWNER approval; direct pushes to `main` are disabled

--- a/skills/generate-tests/SKILL.md
+++ b/skills/generate-tests/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: generate-tests
-description: "Use when the user asks to generate, create, or write unit tests for code. Analyzes the target code, produces a structured test case list for review, then generates test code. Supports Java (JUnit 5, Mockito, AssertJ)."
+description: "Use when the user asks to generate, create, or write unit tests for code. Analyzes the target code, produces a structured test case list for review, then generates test code. Supports Java (JUnit 5, Mockito, AssertJ), including integration tests for repositories, messaging, HTTP clients and configuration properties."
 allowed-tools: Read, Write, Glob, Grep, Bash, AskUserQuestion
 context: fork
 ---
@@ -84,8 +84,11 @@ Options:
 1. Determine code type and apply the matching rules:
    - **Controller** → Apply `controller-test-rules.md` (use `@WebMvcTest`, MockMvc patterns)
    - **Service / Domain logic** → Apply `domain-service-rules.md` (use `@ExtendWith(MockitoExtension.class)`, Mockito patterns)
-   - **Repository / Messaging / Other types** → Apply `domain-service-rules.md` as baseline; inform the user that type-specific rules are not yet available
+   - **Repository / Messaging / External HTTP client / `@ConfigurationProperties`** → These are tested against real infrastructure, not mocks. Apply the matching rule from `java/integration/` (see Rules Reference) and tell the user the generated test is an integration test, not a unit test
+   - **Other types** → Apply `domain-service-rules.md` as baseline; inform the user that type-specific rules are not yet available
    - **All Java code** → Always apply `java-test-template.md`, `argument-matching.md`, `json-serialization.md` regardless of code type
+
+   The `@SpringBootTest` ban in `java-test-template.md` applies to unit tests. Integration rules that call for `@SpringBootTest` or Testcontainers override it for the test types they cover.
 2. If an existing test class was found in Step 1, add new test methods to it (do not create a duplicate file)
 3. Generate tests following all rules and the test cases from Step 2
 4. Create or update the test file using the Write tool
@@ -180,6 +183,17 @@ Result: Complete test file delivered with 7 passing tests.
 - `java/unit/logging-rules.md` - OutputCaptureExtension for logs
 - `java/unit/domain-service-rules.md` - Mockito patterns for services
 - `java/unit/controller-test-rules.md` - @WebMvcTest and MockMvc patterns for controllers
+
+### Java Integration Tests (apply only for the code type each one names)
+- `java/integration/jpa-repository-rules.md` - @DataJpaTest with a real database via Testcontainers
+- `java/integration/external-http-wiremock.md` - WireMock for HTTP clients, instead of mocking the client
+- `java/integration/kafka-consumer-rules.md` - Kafka consumers with @EmbeddedKafka or Testcontainers
+- `java/integration/kafka-producer-rules.md` - Kafka producers verified through a real consumer
+- `java/integration/rabbitmq-rules.md` - RabbitMQ producers and consumers with RabbitMQContainer
+- `java/integration/redis-pubsub-rules.md` - Redis Pub/Sub messaging
+- `java/integration/redis-cache-rules.md` - Spring Cache backed by Redis
+- `java/integration/aws-rules.md` - S3, DynamoDB and SQS via LocalStack
+- `java/integration/configuration-properties-rules.md` - @ConfigurationProperties binding and validation
 
 ### Post-Generation
 - `post-generation/compilation-verification.md` - Verify compilation

--- a/skills/generate-tests/rules/tests/java/integration/aws-rules.md
+++ b/skills/generate-tests/rules/tests/java/integration/aws-rules.md
@@ -1,0 +1,245 @@
+---
+title: AWS Services Test Rules (S3, DynamoDB, SQS)
+impact: HIGH
+impactDescription: ensures proper testing of AWS services with LocalStack containers
+tags: java, tests, integration, aws, s3, dynamodb, sqs, testcontainers, localstack
+---
+
+## AWS Services Test Rules
+
+Use Testcontainers with LocalStackContainer for testing AWS services. Never mock AWS clients.
+
+### Rules
+
+- **MUST NOT** use `@SpringBootTest` or `MockitoExtension`
+- **MUST** use `@Testcontainers` with `LocalStackContainer`
+- Use `@Container` for static instance of container
+- Isolate data per test using cleanup in `@AfterEach`
+- Configure AWS clients to use LocalStack endpoint
+
+**Incorrect:**
+
+```java
+// Mocking AWS clients - wrong!
+@ExtendWith(MockitoExtension.class)
+class S3ServiceTest {
+    @Mock
+    private S3Client s3Client;
+}
+
+// Using @SpringBootTest - too heavy
+@SpringBootTest
+class S3ServiceIT {
+    // ...
+}
+```
+
+**Correct:**
+
+### S3 Test Template
+
+```java
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.CreateBucketRequest;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.ListObjectsV2Request;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.S3;
+
+@Testcontainers
+class S3ServiceIT {
+
+    @Container
+    static final LocalStackContainer localstack = new LocalStackContainer(
+            DockerImageName.parse("localstack/localstack:3.0"))
+            .withServices(S3);
+
+    private S3Client s3Client;
+    private S3Service s3Service;
+
+    @BeforeEach
+    void setUp() {
+        s3Client = S3Client.builder()
+                .endpointOverride(localstack.getEndpointOverride(S3))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(localstack.getAccessKey(), localstack.getSecretKey())))
+                .region(Region.of(localstack.getRegion()))
+                .build();
+
+        s3Client.createBucket(CreateBucketRequest.builder().bucket("test-bucket").build());
+        s3Service = new S3Service(s3Client, "test-bucket");
+    }
+
+    @AfterEach
+    void tearDown() {
+        // Clean up all objects
+        var objects = s3Client.listObjectsV2(ListObjectsV2Request.builder()
+                .bucket("test-bucket").build());
+        objects.contents().forEach(obj ->
+                s3Client.deleteObject(DeleteObjectRequest.builder()
+                        .bucket("test-bucket")
+                        .key(obj.key())
+                        .build()));
+    }
+
+    @Test
+    void uploadFile_validContent_uploadsSuccessfully() {
+        // When
+        s3Service.uploadFile("test-key", "test content");
+
+        // Then
+        var objects = s3Client.listObjectsV2(ListObjectsV2Request.builder()
+                .bucket("test-bucket").build());
+        assertThat(objects.contents()).hasSize(1);
+        assertThat(objects.contents().get(0).key()).isEqualTo("test-key");
+    }
+
+    @Test
+    void downloadFile_existingKey_returnsContent() {
+        // Given
+        s3Service.uploadFile("test-key", "test content");
+
+        // When
+        String content = s3Service.downloadFile("test-key");
+
+        // Then
+        assertThat(content).isEqualTo("test content");
+    }
+}
+```
+
+### DynamoDB Test Template
+
+```java
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import software.amazon.awssdk.services.dynamodb.DynamoDbClient;
+import software.amazon.awssdk.services.dynamodb.model.*;
+
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.DYNAMODB;
+
+@Testcontainers
+class DynamoDbServiceIT {
+
+    @Container
+    static final LocalStackContainer localstack = new LocalStackContainer(
+            DockerImageName.parse("localstack/localstack:3.0"))
+            .withServices(DYNAMODB);
+
+    private DynamoDbClient dynamoDbClient;
+    private DynamoDbService dynamoDbService;
+
+    @BeforeEach
+    void setUp() {
+        dynamoDbClient = DynamoDbClient.builder()
+                .endpointOverride(localstack.getEndpointOverride(DYNAMODB))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(localstack.getAccessKey(), localstack.getSecretKey())))
+                .region(Region.of(localstack.getRegion()))
+                .build();
+
+        // Create table
+        dynamoDbClient.createTable(CreateTableRequest.builder()
+                .tableName("test-table")
+                .keySchema(KeySchemaElement.builder()
+                        .attributeName("id")
+                        .keyType(KeyType.HASH)
+                        .build())
+                .attributeDefinitions(AttributeDefinition.builder()
+                        .attributeName("id")
+                        .attributeType(ScalarAttributeType.S)
+                        .build())
+                .billingMode(BillingMode.PAY_PER_REQUEST)
+                .build());
+
+        dynamoDbService = new DynamoDbService(dynamoDbClient, "test-table");
+    }
+
+    @Test
+    void putItem_validItem_savesSuccessfully() {
+        // When
+        dynamoDbService.putItem("item-1", "test value");
+
+        // Then
+        var result = dynamoDbClient.getItem(GetItemRequest.builder()
+                .tableName("test-table")
+                .key(Map.of("id", AttributeValue.builder().s("item-1").build()))
+                .build());
+        assertThat(result.item()).isNotEmpty();
+    }
+}
+```
+
+### SQS Test Template
+
+```java
+import org.testcontainers.containers.localstack.LocalStackContainer;
+import software.amazon.awssdk.services.sqs.SqsClient;
+import software.amazon.awssdk.services.sqs.model.*;
+
+import static org.testcontainers.containers.localstack.LocalStackContainer.Service.SQS;
+
+@Testcontainers
+class SqsServiceIT {
+
+    @Container
+    static final LocalStackContainer localstack = new LocalStackContainer(
+            DockerImageName.parse("localstack/localstack:3.0"))
+            .withServices(SQS);
+
+    private SqsClient sqsClient;
+    private String queueUrl;
+    private SqsService sqsService;
+
+    @BeforeEach
+    void setUp() {
+        sqsClient = SqsClient.builder()
+                .endpointOverride(localstack.getEndpointOverride(SQS))
+                .credentialsProvider(StaticCredentialsProvider.create(
+                        AwsBasicCredentials.create(localstack.getAccessKey(), localstack.getSecretKey())))
+                .region(Region.of(localstack.getRegion()))
+                .build();
+
+        queueUrl = sqsClient.createQueue(CreateQueueRequest.builder()
+                .queueName("test-queue")
+                .build()).queueUrl();
+
+        sqsService = new SqsService(sqsClient, queueUrl);
+    }
+
+    @Test
+    void sendMessage_validMessage_sendsSuccessfully() {
+        // When
+        sqsService.sendMessage("test message");
+
+        // Then
+        var messages = sqsClient.receiveMessage(ReceiveMessageRequest.builder()
+                .queueUrl(queueUrl)
+                .maxNumberOfMessages(1)
+                .build()).messages();
+        assertThat(messages).hasSize(1);
+        assertThat(messages.get(0).body()).isEqualTo("test message");
+    }
+}
+```
+
+### Key Points
+
+1. Use `LocalStackContainer` with appropriate services
+2. Configure AWS clients with LocalStack endpoint and credentials
+3. Create resources (buckets, tables, queues) in `@BeforeEach`
+4. Clean up data in `@AfterEach`
+5. Use AWS SDK v2 for cleaner API

--- a/skills/generate-tests/rules/tests/java/integration/configuration-properties-rules.md
+++ b/skills/generate-tests/rules/tests/java/integration/configuration-properties-rules.md
@@ -1,0 +1,365 @@
+---
+title: ConfigurationProperties Test Rules
+impact: MEDIUM
+impactDescription: ensures configuration properties are properly loaded and validated
+tags: java, tests, integration, configuration, properties, spring-boot
+---
+
+## ConfigurationProperties Test Rules
+
+Generate TWO test classes for `@ConfigurationProperties` classes: unit test and integration test.
+
+### Rules
+
+- Generate unit test (no Spring context) for validation and defaults
+- Generate integration test with `@SpringBootTest` and custom yml config file
+- Integration test file should be named `{PropertiesClassName}IT`
+- Create a test YAML file with test configuration data
+
+**Incorrect:**
+
+```java
+// Only unit test - doesn't verify Spring binding
+@Test
+void properties_validValues_setsFields() {
+    var props = new AppProperties();
+    props.setName("test");
+    assertThat(props.getName()).isEqualTo("test");
+}
+
+// Using application.yml - affects production config
+@SpringBootTest
+class AppPropertiesIT {
+    // Uses main application.yml - wrong!
+}
+```
+
+**Correct:**
+
+### 1. Unit Test (No Spring Context)
+
+```java
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class AppPropertiesTest {
+
+    @Test
+    void defaultValues_notSet_returnsDefaults() {
+        // Given
+        var properties = new AppProperties();
+
+        // Then
+        assertThat(properties.getTimeout()).isEqualTo(30); // default value
+        assertThat(properties.isEnabled()).isTrue(); // default value
+    }
+
+    @Test
+    void setName_validValue_setsField() {
+        // Given
+        var properties = new AppProperties();
+
+        // When
+        properties.setName("test-app");
+
+        // Then
+        assertThat(properties.getName()).isEqualTo("test-app");
+    }
+
+    @Test
+    void setters_allFields_setsCorrectly() {
+        // Given
+        var properties = new AppProperties();
+
+        // When
+        properties.setName("my-app");
+        properties.setTimeout(60);
+        properties.setEnabled(false);
+        properties.setEndpoint("http://localhost:8080");
+
+        // Then
+        assertThat(properties.getName()).isEqualTo("my-app");
+        assertThat(properties.getTimeout()).isEqualTo(60);
+        assertThat(properties.isEnabled()).isFalse();
+        assertThat(properties.getEndpoint()).isEqualTo("http://localhost:8080");
+    }
+
+    @Test
+    void nestedProperties_validValues_setsNestedFields() {
+        // Given
+        var properties = new AppProperties();
+        var security = new AppProperties.SecurityProperties();
+
+        // When
+        security.setApiKey("secret-key");
+        security.setTokenExpiry(3600);
+        properties.setSecurity(security);
+
+        // Then
+        assertThat(properties.getSecurity().getApiKey()).isEqualTo("secret-key");
+        assertThat(properties.getSecurity().getTokenExpiry()).isEqualTo(3600);
+    }
+}
+```
+
+### 2. Integration Test with Custom YAML
+
+First, create the test YAML file at `src/test/java/{package}/app-properties.yml`:
+
+```yaml
+# src/test/java/com/example/config/app-properties.yml
+app:
+  name: integration-test-app
+  timeout: 120
+  enabled: true
+  endpoint: http://test-endpoint:9090
+  security:
+    api-key: test-api-key-12345
+    token-expiry: 7200
+```
+
+Then create the integration test:
+
+```java
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.TestConfiguration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest(
+        classes = {AppProperties.class, AppPropertiesIT.TestConfig.class},
+        properties = {"spring.config.location=file:src/test/java/com/example/config/app-properties.yml"}
+)
+class AppPropertiesIT {
+
+    @Autowired
+    private AppProperties appProperties;
+
+    @Test
+    void name_fromYaml_loadsCorrectly() {
+        assertThat(appProperties.getName()).isEqualTo("integration-test-app");
+    }
+
+    @Test
+    void timeout_fromYaml_loadsCorrectly() {
+        assertThat(appProperties.getTimeout()).isEqualTo(120);
+    }
+
+    @Test
+    void enabled_fromYaml_loadsCorrectly() {
+        assertThat(appProperties.isEnabled()).isTrue();
+    }
+
+    @Test
+    void endpoint_fromYaml_loadsCorrectly() {
+        assertThat(appProperties.getEndpoint()).isEqualTo("http://test-endpoint:9090");
+    }
+
+    @Test
+    void securityApiKey_fromYaml_loadsNestedProperty() {
+        assertThat(appProperties.getSecurity().getApiKey()).isEqualTo("test-api-key-12345");
+    }
+
+    @Test
+    void securityTokenExpiry_fromYaml_loadsNestedProperty() {
+        assertThat(appProperties.getSecurity().getTokenExpiry()).isEqualTo(7200);
+    }
+
+    @Test
+    void allProperties_fromYaml_allLoadedCorrectly() {
+        assertThat(appProperties.getName()).isNotNull();
+        assertThat(appProperties.getTimeout()).isPositive();
+        assertThat(appProperties.getEndpoint()).startsWith("http://");
+        assertThat(appProperties.getSecurity()).isNotNull();
+        assertThat(appProperties.getSecurity().getApiKey()).isNotEmpty();
+    }
+
+    @TestConfiguration
+    @EnableConfigurationProperties(AppProperties.class)
+    static class TestConfig {
+    }
+}
+```
+
+### 3. Validation Tests (MANDATORY)
+
+**CRITICAL: Always generate negative test cases for validation annotations!**
+
+For each validation annotation (`@NotBlank`, `@NotNull`, `@Pattern`, `@Valid`, custom validators), create test cases that verify validation FAILS with invalid input.
+
+```java
+import jakarta.validation.ConstraintViolation;
+import jakarta.validation.Validation;
+import jakarta.validation.Validator;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AppPropertiesValidationTest {
+
+    private Validator validator;
+
+    @BeforeEach
+    void setUp() {
+        validator = Validation.buildDefaultValidatorFactory().getValidator();
+    }
+
+    // @NotBlank validation
+    @Test
+    void name_blank_failsValidation() {
+        // Given
+        var properties = new AppProperties();
+        properties.setName("   "); // blank
+
+        // When
+        Set<ConstraintViolation<AppProperties>> violations = validator.validate(properties);
+
+        // Then
+        assertThat(violations)
+                .extracting(v -> v.getPropertyPath().toString())
+                .contains("name");
+    }
+
+    @Test
+    void name_null_failsValidation() {
+        // Given
+        var properties = new AppProperties();
+        properties.setName(null);
+
+        // When
+        Set<ConstraintViolation<AppProperties>> violations = validator.validate(properties);
+
+        // Then
+        assertThat(violations)
+                .extracting(v -> v.getPropertyPath().toString())
+                .contains("name");
+    }
+
+    // @Pattern validation
+    @Test
+    void currency_invalidPattern_failsValidation() {
+        // Given
+        var properties = new AppProperties();
+        properties.setCurrency("usd"); // lowercase - invalid
+
+        // When
+        Set<ConstraintViolation<AppProperties>> violations = validator.validate(properties);
+
+        // Then
+        assertThat(violations)
+                .extracting(v -> v.getPropertyPath().toString())
+                .contains("currency");
+    }
+
+    @Test
+    void currency_tooShort_failsValidation() {
+        // Given
+        var properties = new AppProperties();
+        properties.setCurrency("US"); // only 2 chars
+
+        // When
+        Set<ConstraintViolation<AppProperties>> violations = validator.validate(properties);
+
+        // Then
+        assertThat(violations)
+                .extracting(v -> v.getPropertyPath().toString())
+                .contains("currency");
+    }
+
+    // @Valid on nested objects - validation propagates
+    @Test
+    void nestedCredentials_invalidApiKey_failsValidation() {
+        // Given
+        var properties = new AppProperties();
+        var credentials = new AppProperties.Credentials();
+        credentials.setApiKey(""); // blank - invalid
+        properties.setCredentials(credentials);
+
+        // When
+        Set<ConstraintViolation<AppProperties>> violations = validator.validate(properties);
+
+        // Then
+        assertThat(violations)
+                .extracting(v -> v.getPropertyPath().toString())
+                .contains("credentials.apiKey");
+    }
+
+    // Custom validators
+    @Test
+    void items_duplicateValues_failsCustomValidation() {
+        // Given
+        var properties = new AppProperties();
+        properties.setItems(List.of(
+                new Item("key1", "value1"),
+                new Item("key1", "value2") // duplicate key - violates @UniqueByProperty
+        ));
+
+        // When
+        Set<ConstraintViolation<AppProperties>> violations = validator.validate(properties);
+
+        // Then
+        assertThat(violations).isNotEmpty();
+        assertThat(violations)
+                .extracting(ConstraintViolation::getMessage)
+                .anyMatch(msg -> msg.contains("unique") || msg.contains("duplicate"));
+    }
+
+    // Positive cases - valid values pass
+    @Test
+    void allFields_validValues_passesValidation() {
+        // Given
+        var properties = createValidProperties();
+
+        // When
+        Set<ConstraintViolation<AppProperties>> violations = validator.validate(properties);
+
+        // Then
+        assertThat(violations).isEmpty();
+    }
+
+    private AppProperties createValidProperties() {
+        var properties = new AppProperties();
+        properties.setName("valid-name");
+        properties.setCurrency("USD");
+        // ... set all required fields with valid values
+        return properties;
+    }
+}
+```
+
+### Key Points
+
+1. Unit test verifies setters/getters and default values
+2. Integration test verifies Spring binding from YAML
+3. **Validation test verifies constraints with invalid input (MANDATORY)**
+4. Create separate test YAML file (not main application.yml)
+5. Use `spring.config.location` to point to test YAML
+6. Test every property to ensure it loads correctly
+7. Test nested properties separately
+8. Include `@EnableConfigurationProperties` in `@TestConfiguration`
+
+### Validation Test Cases Checklist
+
+For each field, generate test cases based on its annotations:
+
+| Annotation | Negative Test Cases |
+|------------|---------------------|
+| `@NotBlank` | blank string `"   "`, empty string `""`, `null` |
+| `@NotNull` | `null` value |
+| `@NotEmpty` | empty collection/string, `null` |
+| `@Pattern` | values that don't match regex (wrong case, wrong length, wrong format) |
+| `@Min/@Max` | values below min, values above max |
+| `@Size` | values shorter than min, values longer than max |
+| `@Email` | invalid email format |
+| `@Valid` (nested) | nested object with invalid fields |
+| Custom validators | values that violate custom logic (duplicates, invalid combinations) |
+
+**CRITICAL: If a class has ANY validation annotation, you MUST generate negative test cases for it.**

--- a/skills/generate-tests/rules/tests/java/integration/external-http-wiremock.md
+++ b/skills/generate-tests/rules/tests/java/integration/external-http-wiremock.md
@@ -1,0 +1,181 @@
+---
+title: External HTTP Client Test Rules (WireMock)
+impact: HIGH
+impactDescription: ensures proper HTTP client testing without mocking clients
+tags: java, tests, integration, wiremock, http-client, resttemplate, webclient
+---
+
+## External HTTP Client Test Rules (WireMock)
+
+Use WireMock for testing code that makes external HTTP calls. Never mock HTTP clients directly.
+
+### Rules
+
+- **DO NOT** mock HTTP clients (RestTemplate/WebClient/java.net.http.HttpClient/OkHttp)
+- Tests **MUST** use `@WireMockTest` with setup method signature: `void setUp(WireMockRuntimeInfo runtimeInfo)`
+- Obtain base URL from `runtimeInfo.getHttpBaseUrl()` and pass it to SUT via constructor/setter
+- **DO NOT** use `wireMock.baseUrl()` - use `runtimeInfo.getHttpBaseUrl()`
+- Prefer DI/config to control base URL
+- **DO NOT** subclass or override SUT methods in tests to change base URL
+- If you must mutate a private field, use `ReflectionTestUtils`
+- **FORBID** manual server lifecycle: do NOT call `new ...Server().start()/stop()`
+- Always include expected JSON body and Content-Type header matcher for request stubs
+
+**Incorrect:**
+
+```java
+// Mocking the HTTP client - WRONG
+@Test
+void fetchData_validResponse_returnsData() {
+    var mockRestTemplate = mock(RestTemplate.class);
+    when(mockRestTemplate.getForObject(anyString(), eq(Data.class)))
+            .thenReturn(new Data("test"));
+
+    var result = service.fetchData();
+
+    assertThat(result.getValue()).isEqualTo("test");
+}
+
+// Manual server lifecycle - WRONG
+@Test
+void fetchData_validResponse_returnsData() {
+    WireMockServer server = new WireMockServer();
+    server.start();
+    // ...
+    server.stop();
+}
+
+// Using wireMock.baseUrl() - WRONG
+void setUp(WireMockRuntimeInfo runtimeInfo, WireMock wireMock) {
+    service = new ExternalService(wireMock.baseUrl());
+}
+```
+
+**Correct:**
+
+```java
+import com.github.tomakehurst.wiremock.junit5.WireMockRuntimeInfo;
+import com.github.tomakehurst.wiremock.junit5.WireMockTest;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import static com.github.tomakehurst.wiremock.client.WireMock.*;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@WireMockTest
+class ExternalServiceTest {
+
+    private ExternalService externalService;
+
+    @BeforeEach
+    void setUp(WireMockRuntimeInfo runtimeInfo) {
+        // Pass base URL via constructor or setter
+        externalService = new ExternalService(runtimeInfo.getHttpBaseUrl());
+    }
+
+    @Test
+    void fetchData_validResponse_returnsData() {
+        // Given
+        stubFor(get("/api/data")
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {
+                                    "id": "123",
+                                    "value": "test-data"
+                                }
+                                """)));
+
+        // When
+        Data actualData = externalService.fetchData();
+
+        // Then
+        assertThat(actualData.getId()).isEqualTo("123");
+        assertThat(actualData.getValue()).isEqualTo("test-data");
+
+        // Verify request was made
+        verify(getRequestedFor(urlEqualTo("/api/data")));
+    }
+
+    @Test
+    void createResource_validRequest_sendsCorrectBody() {
+        // Given
+        stubFor(post("/api/resources")
+                .withHeader("Content-Type", equalTo("application/json"))
+                .withRequestBody(equalToJson("""
+                        {
+                            "name": "test-resource",
+                            "type": "A"
+                        }
+                        """))
+                .willReturn(aResponse()
+                        .withStatus(201)
+                        .withHeader("Content-Type", "application/json")
+                        .withBody("""
+                                {
+                                    "id": "new-123",
+                                    "name": "test-resource"
+                                }
+                                """)));
+
+        // When
+        var request = new CreateRequest("test-resource", "A");
+        Resource actualResource = externalService.createResource(request);
+
+        // Then
+        assertThat(actualResource.getId()).isEqualTo("new-123");
+
+        verify(postRequestedFor(urlEqualTo("/api/resources"))
+                .withHeader("Content-Type", equalTo("application/json")));
+    }
+
+    @Test
+    void fetchData_serverError_throwsServiceException() {
+        // Given
+        stubFor(get("/api/data")
+                .willReturn(aResponse()
+                        .withStatus(500)
+                        .withBody("Internal Server Error")));
+
+        // When-Then
+        assertThatThrownBy(() -> externalService.fetchData())
+                .isInstanceOf(ServiceException.class)
+                .hasMessageContaining("Failed to fetch data");
+    }
+
+    @Test
+    void fetchData_timeout_throwsServiceException() {
+        // Given
+        stubFor(get("/api/data")
+                .willReturn(aResponse()
+                        .withStatus(200)
+                        .withFixedDelay(5000))); // Simulate timeout
+
+        // When-Then
+        assertThatThrownBy(() -> externalService.fetchData())
+                .isInstanceOf(ServiceException.class);
+    }
+}
+```
+
+### Using ReflectionTestUtils for Private Fields
+
+When you cannot modify the SUT constructor:
+
+```java
+@BeforeEach
+void setUp(WireMockRuntimeInfo runtimeInfo) {
+    externalService = new ExternalService();
+    ReflectionTestUtils.setField(externalService, "baseUrl", runtimeInfo.getHttpBaseUrl());
+}
+```
+
+### Key Points
+
+1. Let WireMock extension manage server lifecycle
+2. Always verify requests were made as expected
+3. Include Content-Type headers in stubs
+4. Use explicit JSON bodies, not serializers
+5. Test error scenarios (500, timeout, etc.)

--- a/skills/generate-tests/rules/tests/java/integration/jpa-repository-rules.md
+++ b/skills/generate-tests/rules/tests/java/integration/jpa-repository-rules.md
@@ -1,0 +1,177 @@
+---
+title: JPA Repository Test Rules
+impact: HIGH
+impactDescription: ensures proper database testing with real database containers
+tags: java, tests, integration, jpa, repository, testcontainers, database
+---
+
+## JPA Repository Test Rules
+
+Use Testcontainers with `@DataJpaTest` for repository tests. Never use embedded databases or mock repositories.
+
+### Rules
+
+- **MUST NOT** use `@SpringBootTest` or `MockitoExtension`
+- **MUST** use `@Testcontainers`
+- Use `@DataJpaTest` with `@AutoConfigureTestDatabase(replace = Replace.NONE)` to disable embedded DB
+- Use `@Container` for static container instance
+- Configure via `@DynamicPropertySource`
+- Set `spring.jpa.hibernate.ddl-auto` to `"create"` in `@DynamicPropertySource`
+- Isolate data per test using `@AfterEach` with `deleteAll()` cleanup
+
+**Incorrect:**
+
+```java
+// Using embedded H2 - doesn't test real DB behavior
+@DataJpaTest
+class UserRepositoryTest {
+    // Uses H2 by default - wrong!
+}
+
+// Using @SpringBootTest - too heavy
+@SpringBootTest
+class UserRepositoryTest {
+    // Loads entire context - wrong!
+}
+
+// Mocking repository - not testing actual queries
+@ExtendWith(MockitoExtension.class)
+class UserRepositoryTest {
+    @Mock
+    private UserRepository userRepository;
+}
+```
+
+**Correct:**
+
+```java
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.jdbc.AutoConfigureTestDatabase;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.testcontainers.containers.PostgreSQLContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@DataJpaTest
+@AutoConfigureTestDatabase(replace = AutoConfigureTestDatabase.Replace.NONE)
+class UserRepositoryTest {
+
+    @Container
+    static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
+
+    @DynamicPropertySource
+    static void configureProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.datasource.url", postgres::getJdbcUrl);
+        registry.add("spring.datasource.username", postgres::getUsername);
+        registry.add("spring.datasource.password", postgres::getPassword);
+        registry.add("spring.jpa.hibernate.ddl-auto", () -> "create");
+    }
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @AfterEach
+    void tearDown() {
+        userRepository.deleteAll();
+    }
+
+    @Test
+    void save_validUser_persistsToDatabase() {
+        // Given
+        var user = new User("john@test.com", "John Doe");
+
+        // When
+        User savedUser = userRepository.save(user);
+
+        // Then
+        assertThat(savedUser.getId()).isNotNull();
+        assertThat(savedUser.getEmail()).isEqualTo("john@test.com");
+    }
+
+    @Test
+    void findByEmail_existingUser_returnsUser() {
+        // Given
+        var user = new User("john@test.com", "John Doe");
+        userRepository.save(user);
+
+        // When
+        var actualUser = userRepository.findByEmail("john@test.com");
+
+        // Then
+        assertThat(actualUser).isPresent();
+        assertThat(actualUser.get().getName()).isEqualTo("John Doe");
+    }
+
+    @Test
+    void findByEmail_nonExistentUser_returnsEmpty() {
+        // When
+        var actualUser = userRepository.findByEmail("unknown@test.com");
+
+        // Then
+        assertThat(actualUser).isEmpty();
+    }
+
+    @Test
+    void findAllByStatus_multipleUsers_returnsMatchingUsers() {
+        // Given
+        userRepository.save(new User("active1@test.com", "Active 1", UserStatus.ACTIVE));
+        userRepository.save(new User("active2@test.com", "Active 2", UserStatus.ACTIVE));
+        userRepository.save(new User("inactive@test.com", "Inactive", UserStatus.INACTIVE));
+
+        // When
+        var actualUsers = userRepository.findAllByStatus(UserStatus.ACTIVE);
+
+        // Then
+        assertThat(actualUsers).hasSize(2);
+        assertThat(actualUsers).extracting(User::getEmail)
+                .containsExactlyInAnyOrder("active1@test.com", "active2@test.com");
+    }
+
+    @Test
+    void deleteById_existingUser_removesFromDatabase() {
+        // Given
+        var user = userRepository.save(new User("john@test.com", "John Doe"));
+
+        // When
+        userRepository.deleteById(user.getId());
+
+        // Then
+        assertThat(userRepository.findById(user.getId())).isEmpty();
+    }
+}
+```
+
+### Database Containers by Type
+
+```java
+// PostgreSQL
+@Container
+static final PostgreSQLContainer<?> postgres = new PostgreSQLContainer<>("postgres:15-alpine");
+
+// MySQL
+@Container
+static final MySQLContainer<?> mysql = new MySQLContainer<>("mysql:8.0");
+
+// MariaDB
+@Container
+static final MariaDBContainer<?> mariadb = new MariaDBContainer<>("mariadb:10.6");
+
+// MongoDB (use @DataMongoTest instead of @DataJpaTest)
+@Container
+static final MongoDBContainer mongo = new MongoDBContainer("mongo:6.0");
+```
+
+### Key Points
+
+1. Use real database container matching production
+2. Clean up data after each test for isolation
+3. Test custom query methods
+4. Verify entity relationships and cascades
+5. Test edge cases (empty results, duplicates)

--- a/skills/generate-tests/rules/tests/java/integration/kafka-consumer-rules.md
+++ b/skills/generate-tests/rules/tests/java/integration/kafka-consumer-rules.md
@@ -1,0 +1,179 @@
+---
+title: Kafka Consumer Test Rules
+impact: HIGH
+impactDescription: ensures proper testing of Kafka consumers with embedded and container-based brokers
+tags: java, tests, integration, kafka, consumer, testcontainers, embedded-kafka
+---
+
+## Kafka Consumer Test Rules
+
+Generate TWO test classes for Kafka consumers: one with @EmbeddedKafka and one with @Testcontainers.
+
+### Rules
+
+- Use `@EmbeddedKafka` for unit tests and `@Testcontainers` with `ConfluentKafkaContainer` for integration tests
+- Use `@SpringJUnitConfig` to load only the component under test (no `@SpringBootTest`)
+- Use `@ImportAutoConfiguration(KafkaAutoConfiguration.class)` to enable Kafka infrastructure
+- Use `@DirtiesContext` to reset context after each test
+- Autowire `KafkaTemplate` for sending test messages
+- For integration tests: use `@MockitoSpyBean` to verify listener method calls
+- Use Awaitility for async assertions
+- Set `spring.kafka.consumer.auto-offset-reset=earliest` to read from topic start
+- Do NOT use `@SpringBootTest` or `MockitoExtension`
+- Do NOT manually create topics (rely on auto-creation or `@EmbeddedKafka` topics parameter)
+
+### 1. Unit Test with @EmbeddedKafka
+
+```java
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EmbeddedKafka(partitions = 1, topics = {"orders-topic"})
+@ImportAutoConfiguration(KafkaAutoConfiguration.class)
+@SpringJUnitConfig(OrderConsumer.class)
+@TestPropertySource(properties = {
+        "spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}",
+        "spring.kafka.consumer.auto-offset-reset=earliest"
+})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class OrderConsumerTest {
+
+    @Autowired
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Test
+    void listen_validMessage_processesSuccessfully() {
+        // Given
+        String message = """
+                {"orderId": "123", "product": "test"}
+                """;
+
+        // When
+        kafkaTemplate.send("orders-topic", "key-1", message);
+
+        // Then
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> {
+                    // Assert expected behavior (e.g., database state, logs, etc.)
+                    assertThat(true).isTrue(); // Replace with actual assertion
+                });
+    }
+
+    @Test
+    void listen_invalidMessage_handlesGracefully() {
+        // Given
+        String invalidMessage = "invalid-json";
+
+        // When
+        kafkaTemplate.send("orders-topic", "key-2", invalidMessage);
+
+        // Then
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> {
+                    // Assert error handling behavior
+                });
+    }
+}
+```
+
+### 2. Integration Test with @Testcontainers
+
+```java
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
+import org.springframework.kafka.core.KafkaTemplate;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@Testcontainers
+@SpringJUnitConfig(OrderConsumer.class)
+@ImportAutoConfiguration(KafkaAutoConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class OrderConsumerIT {
+
+    @Container
+    static final ConfluentKafkaContainer kafka = new ConfluentKafkaContainer(
+            DockerImageName.parse("confluentinc/cp-kafka:7.5.0"));
+
+    @DynamicPropertySource
+    static void dynamicProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
+        registry.add("spring.kafka.consumer.auto-offset-reset", () -> "earliest");
+    }
+
+    @MockitoSpyBean
+    private OrderConsumer orderConsumer;
+
+    @Autowired
+    private KafkaTemplate<String, String> kafkaTemplate;
+
+    @Test
+    void listen_validMessage_invokesListener() {
+        // Given
+        String message = """
+                {"orderId": "123", "product": "test"}
+                """;
+
+        // When
+        kafkaTemplate.send("orders-topic", "key-1", message);
+
+        // Then
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> verify(orderConsumer, times(1)).listen(anyString()));
+    }
+
+    @Test
+    void listen_multipleMessages_processesAll() {
+        // Given-When
+        kafkaTemplate.send("orders-topic", "key-1", "message-1");
+        kafkaTemplate.send("orders-topic", "key-2", "message-2");
+        kafkaTemplate.send("orders-topic", "key-3", "message-3");
+
+        // Then
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(15))
+                .untilAsserted(() -> verify(orderConsumer, times(3)).listen(anyString()));
+    }
+}
+```
+
+### Key Points
+
+1. Use `@EmbeddedKafka` for fast unit tests
+2. Use `@Testcontainers` for realistic integration tests
+3. Always set `auto-offset-reset=earliest`
+4. Use Awaitility for async assertions
+5. Use `@MockitoSpyBean` to verify listener invocations
+6. Clean context with `@DirtiesContext` after each test

--- a/skills/generate-tests/rules/tests/java/integration/kafka-producer-rules.md
+++ b/skills/generate-tests/rules/tests/java/integration/kafka-producer-rules.md
@@ -1,0 +1,226 @@
+---
+title: Kafka Producer Test Rules
+impact: HIGH
+impactDescription: ensures proper testing of Kafka producers with consumer verification
+tags: java, tests, integration, kafka, producer, testcontainers, embedded-kafka
+---
+
+## Kafka Producer Test Rules
+
+Generate TWO test classes for Kafka producers: one with @EmbeddedKafka and one with @Testcontainers.
+
+### Rules
+
+- Use `@EmbeddedKafka` for unit tests and `@Testcontainers` with `ConfluentKafkaContainer` for integration tests
+- Use `@SpringJUnitConfig` to load only the producer component under test
+- Use `@ImportAutoConfiguration(KafkaAutoConfiguration.class)` to enable Kafka infrastructure
+- Autowire `ConsumerFactory<String, String>` to create test consumer for verification
+- Create test consumer via `consumerFactory.createConsumer()` in `@BeforeEach`
+- Subscribe test consumer to the producer's target topic
+- Use `KafkaTestUtils.getSingleRecord()` or manual polling for message verification
+- Close test consumer in `@AfterEach` to prevent resource leaks
+- Do NOT use `@SpringBootTest` or `MockitoExtension`
+- Do NOT manually create KafkaConsumer via new operator (use ConsumerFactory)
+
+### 1. Unit Test with @EmbeddedKafka
+
+```java
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.test.context.EmbeddedKafka;
+import org.springframework.kafka.test.utils.KafkaTestUtils;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+
+import java.time.Duration;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@EmbeddedKafka(partitions = 1, topics = {"orders-topic"})
+@SpringJUnitConfig(classes = {OrderProducer.class})
+@ImportAutoConfiguration(KafkaAutoConfiguration.class)
+@TestPropertySource(properties = {
+        "spring.kafka.bootstrap-servers=${spring.embedded.kafka.brokers}",
+        "spring.kafka.consumer.auto-offset-reset=earliest"
+})
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class OrderProducerTest {
+
+    @Autowired
+    private OrderProducer orderProducer;
+
+    @Autowired
+    private ConsumerFactory<String, String> consumerFactory;
+
+    private Consumer<String, String> kafkaConsumer;
+
+    @BeforeEach
+    void setUp() {
+        kafkaConsumer = consumerFactory.createConsumer("test-group", "client-id");
+        kafkaConsumer.subscribe(Collections.singletonList("orders-topic"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (kafkaConsumer != null) {
+            kafkaConsumer.close();
+        }
+    }
+
+    @Test
+    void send_validMessage_publishesToTopic() {
+        // Given
+        String key = "order-123";
+        String value = """
+                {"orderId": "123", "product": "test"}
+                """;
+
+        // When
+        orderProducer.send(key, value);
+
+        // Then
+        ConsumerRecord<String, String> record = KafkaTestUtils.getSingleRecord(
+                kafkaConsumer, "orders-topic", Duration.ofSeconds(10));
+
+        assertThat(record.key()).isEqualTo(key);
+        assertThat(record.value()).isEqualTo(value);
+    }
+
+    @Test
+    void send_multipleMessages_publishesAll() {
+        // When
+        orderProducer.send("key-1", "value-1");
+        orderProducer.send("key-2", "value-2");
+
+        // Then
+        var records = KafkaTestUtils.getRecords(kafkaConsumer, Duration.ofSeconds(10));
+
+        assertThat(records.count()).isGreaterThanOrEqualTo(2);
+    }
+}
+```
+
+### 2. Integration Test with @Testcontainers
+
+```java
+import org.apache.kafka.clients.consumer.Consumer;
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.kafka.KafkaAutoConfiguration;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.kafka.ConfluentKafkaContainer;
+import org.testcontainers.utility.DockerImageName;
+
+import java.time.Duration;
+import java.util.Collections;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@SpringJUnitConfig(OrderProducer.class)
+@ImportAutoConfiguration(KafkaAutoConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class OrderProducerIT {
+
+    @Container
+    static final ConfluentKafkaContainer kafka = new ConfluentKafkaContainer(
+            DockerImageName.parse("confluentinc/cp-kafka:7.5.0"));
+
+    @DynamicPropertySource
+    static void registerKafkaProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.kafka.bootstrap-servers", kafka::getBootstrapServers);
+        registry.add("spring.kafka.consumer.auto-offset-reset", () -> "earliest");
+    }
+
+    @Autowired
+    private OrderProducer orderProducer;
+
+    @Autowired
+    private ConsumerFactory<String, String> consumerFactory;
+
+    private Consumer<String, String> kafkaConsumer;
+
+    @BeforeEach
+    void setUp() {
+        kafkaConsumer = consumerFactory.createConsumer("test-group", "client-id");
+        kafkaConsumer.subscribe(Collections.singletonList("orders-topic"));
+    }
+
+    @AfterEach
+    void tearDown() {
+        if (kafkaConsumer != null) {
+            kafkaConsumer.close();
+        }
+    }
+
+    @Test
+    void send_validMessage_publishesToTopic() {
+        // Given
+        String key = "order-123";
+        String value = """
+                {"orderId": "123", "product": "test"}
+                """;
+
+        // When
+        orderProducer.send(key, value);
+
+        // Then
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(200))
+                .untilAsserted(() -> {
+                    var records = kafkaConsumer.poll(Duration.ofMillis(500));
+                    assertThat(records).isNotEmpty();
+                    var record = records.iterator().next();
+                    assertThat(record.key()).isEqualTo(key);
+                    assertThat(record.value()).isEqualTo(value);
+                });
+    }
+
+    @Test
+    void send_withCallback_executesOnSuccess() {
+        // Given
+        var callbackInvoked = new java.util.concurrent.atomic.AtomicBoolean(false);
+
+        // When
+        orderProducer.sendWithCallback("key", "value", (metadata, exception) -> {
+            if (exception == null) {
+                callbackInvoked.set(true);
+            }
+        });
+
+        // Then
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> assertThat(callbackInvoked.get()).isTrue());
+    }
+}
+```
+
+### Key Points
+
+1. Use `ConsumerFactory` to create test consumers (not `new KafkaConsumer()`)
+2. Always close consumers in `@AfterEach`
+3. Subscribe to the correct topic before sending
+4. Use `KafkaTestUtils` for convenient record retrieval
+5. Use Awaitility for async assertions in integration tests
+6. Clean context with `@DirtiesContext` after each test

--- a/skills/generate-tests/rules/tests/java/integration/rabbitmq-rules.md
+++ b/skills/generate-tests/rules/tests/java/integration/rabbitmq-rules.md
@@ -1,0 +1,206 @@
+---
+title: RabbitMQ Test Rules
+impact: HIGH
+impactDescription: ensures proper testing of RabbitMQ producers and consumers with containers
+tags: java, tests, integration, rabbitmq, testcontainers, messaging
+---
+
+## RabbitMQ Test Rules
+
+Use Testcontainers with RabbitMQContainer for integration tests. Never use embedded or mocked brokers.
+
+### Rules
+
+- Use `@Testcontainers` with `RabbitMQContainer` for integration tests
+- Use `@SpringJUnitConfig` to load only the component under test and inline QueueConfig
+- Use `@ImportAutoConfiguration(RabbitAutoConfiguration.class)` to enable RabbitMQ infrastructure
+- Use `RabbitMQContainer` with image `"rabbitmq:3-management"` (use latest)
+- Use `@DynamicPropertySource` to inject container connection properties (host, port, username, password)
+- Use `@DirtiesContext` to reset context after each test method
+- Declare Queue beans in inline `@TestConfiguration` (not `@Configuration`)
+- Set queue `durable=false` for tests (faster creation, auto-cleanup)
+- Use `QueueBuilder.nonDurable().autoDelete()` for test queues
+- For Consumer tests: autowire `RabbitTemplate` to send test messages
+- For Producer tests: use `RabbitTemplate.receive()` for verification
+- Use Awaitility for async assertions
+- Do NOT use `@SpringBootTest`
+- Do NOT manually create RabbitMQ connection/channel
+- Do NOT use raw `com.rabbitmq.client` classes for verification
+
+**Incorrect:**
+
+```java
+// Using @SpringBootTest - too heavy
+@SpringBootTest
+class OrderConsumerIT {
+    // ...
+}
+
+// Manual connection management
+@Test
+void test() {
+    ConnectionFactory factory = new ConnectionFactory();
+    Connection connection = factory.newConnection();
+    Channel channel = connection.createChannel();
+    // ...
+}
+```
+
+**Correct:**
+
+```java
+import org.junit.jupiter.api.Test;
+import org.springframework.amqp.core.Message;
+import org.springframework.amqp.core.Queue;
+import org.springframework.amqp.core.QueueBuilder;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.amqp.RabbitAutoConfiguration;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.testcontainers.containers.RabbitMQContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+
+@Testcontainers
+@SpringJUnitConfig(classes = {OrderProducer.class, OrderProducerIT.QueueConfig.class})
+@ImportAutoConfiguration(RabbitAutoConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class OrderProducerIT {
+
+    @Container
+    static final RabbitMQContainer rabbitMQ = new RabbitMQContainer(
+            DockerImageName.parse("rabbitmq:3-management"));
+
+    @DynamicPropertySource
+    static void dynamicProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.rabbitmq.host", rabbitMQ::getHost);
+        registry.add("spring.rabbitmq.port", rabbitMQ::getAmqpPort);
+        registry.add("spring.rabbitmq.username", rabbitMQ::getAdminUsername);
+        registry.add("spring.rabbitmq.password", rabbitMQ::getAdminPassword);
+    }
+
+    @Autowired
+    private RabbitTemplate rabbitTemplate;
+
+    @Autowired
+    private OrderProducer orderProducer;
+
+    @Test
+    void sendMessage_validOrder_publishesToQueue() {
+        // When
+        orderProducer.sendMessage("test order message");
+
+        // Then
+        await().atMost(Duration.ofSeconds(10))
+                .pollInterval(Duration.ofMillis(200))
+                .untilAsserted(() -> {
+                    Message message = rabbitTemplate.receive("orders-queue", 500);
+                    assertThat(message).isNotNull();
+                    String body = new String(message.getBody(), StandardCharsets.UTF_8);
+                    assertThat(body).isEqualTo("test order message");
+                });
+    }
+
+    @Test
+    void sendMessage_multipleMessages_allDelivered() {
+        // When
+        orderProducer.sendMessage("message-1");
+        orderProducer.sendMessage("message-2");
+
+        // Then
+        await().atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> {
+                    Message msg1 = rabbitTemplate.receive("orders-queue", 500);
+                    Message msg2 = rabbitTemplate.receive("orders-queue", 500);
+                    assertThat(msg1).isNotNull();
+                    assertThat(msg2).isNotNull();
+                });
+    }
+
+    @TestConfiguration
+    static class QueueConfig {
+
+        @Bean
+        public Queue ordersQueue() {
+            return QueueBuilder.nonDurable("orders-queue")
+                    .autoDelete()
+                    .build();
+        }
+    }
+}
+```
+
+### Consumer Test Template
+
+```java
+@Testcontainers
+@SpringJUnitConfig(classes = {OrderConsumer.class, OrderConsumerIT.QueueConfig.class})
+@ImportAutoConfiguration(RabbitAutoConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class OrderConsumerIT {
+
+    @Container
+    static final RabbitMQContainer rabbitMQ = new RabbitMQContainer(
+            DockerImageName.parse("rabbitmq:3-management"));
+
+    @DynamicPropertySource
+    static void dynamicProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.rabbitmq.host", rabbitMQ::getHost);
+        registry.add("spring.rabbitmq.port", rabbitMQ::getAmqpPort);
+        registry.add("spring.rabbitmq.username", rabbitMQ::getAdminUsername);
+        registry.add("spring.rabbitmq.password", rabbitMQ::getAdminPassword);
+    }
+
+    @Autowired
+    private RabbitTemplate rabbitTemplate;
+
+    @Autowired
+    private OrderConsumer orderConsumer;
+
+    @Test
+    void receiveMessage_validMessage_processesSuccessfully() {
+        // When
+        rabbitTemplate.convertAndSend("orders-queue", "test message");
+
+        // Then
+        await().atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> {
+                    // Verify consumer behavior (logs, database state, etc.)
+                    assertThat(true).isTrue(); // Replace with actual assertion
+                });
+    }
+
+    @TestConfiguration
+    static class QueueConfig {
+
+        @Bean
+        public Queue ordersQueue() {
+            return QueueBuilder.nonDurable("orders-queue")
+                    .autoDelete()
+                    .build();
+        }
+    }
+}
+```
+
+### Key Points
+
+1. Use `RabbitMQContainer` with `rabbitmq:3-management` image
+2. Declare test queues in inline `@TestConfiguration`
+3. Use `QueueBuilder.nonDurable().autoDelete()` for test queues
+4. Use `RabbitTemplate` for sending and receiving
+5. Use Awaitility for async assertions
+6. Clean context with `@DirtiesContext`

--- a/skills/generate-tests/rules/tests/java/integration/redis-cache-rules.md
+++ b/skills/generate-tests/rules/tests/java/integration/redis-cache-rules.md
@@ -1,0 +1,188 @@
+---
+title: Redis Cache Test Rules
+impact: HIGH
+impactDescription: ensures proper testing of Spring Cache with Redis backend
+tags: java, tests, integration, redis, cache, testcontainers, spring-cache
+---
+
+## Redis Cache Test Rules
+
+Use Testcontainers with GenericContainer for Redis cache tests. Verify caching behavior properly.
+
+### Rules
+
+- Use `@Testcontainers` with `GenericContainer` for Redis (image `"redis:7-alpine"` or latest)
+- Use `@ImportAutoConfiguration(CacheAutoConfiguration.class)` to enable cache infrastructure
+- Use `@SpringJUnitConfig({ClassName}.class)` to include class under test
+- Use `@EnableCaching` to activate Spring Cache abstraction
+- Use `@DirtiesContext` to reset context after each test method
+- Use `@DynamicPropertySource` to inject container connection properties
+- Autowire `CacheManager` to verify cache state in tests
+- Autowire class under test (annotated with `@Cacheable`, `@CacheEvict`, `@CachePut`)
+- Use `OutputCapture` (via `@ExtendWith(OutputCaptureExtension.class)`) to verify cache hits/misses via logging
+- Verify cache behavior: first call = miss (method invoked), second call = hit (method NOT invoked)
+- Test `@CachePut`, `@CacheEvict`, `@CacheEvict(allEntries=true)` operations
+- Do NOT use `@SpringBootTest`
+- Always verify cache state via `cacheManager.getCache("cacheName").get(key)`
+
+**Incorrect:**
+
+```java
+// Using @SpringBootTest - too heavy
+@SpringBootTest
+class CachingServiceIT {
+    // ...
+}
+
+// Not verifying actual cache behavior
+@Test
+void getData_called_returnsData() {
+    var result = service.getData("key");
+    assertThat(result).isNotNull();
+    // Not testing caching!
+}
+```
+
+**Correct:**
+
+```java
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.cache.CacheAutoConfiguration;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+import org.springframework.cache.CacheManager;
+import org.springframework.cache.annotation.EnableCaching;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@ImportAutoConfiguration(CacheAutoConfiguration.class)
+@EnableCaching
+@SpringJUnitConfig(DataService.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+@ExtendWith(OutputCaptureExtension.class)
+class DataServiceIT {
+
+    @Container
+    static final GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", redis::getFirstMappedPort);
+        registry.add("spring.cache.type", () -> "redis");
+    }
+
+    @Autowired
+    private CacheManager cacheManager;
+
+    @Autowired
+    private DataService dataService;
+
+    @Test
+    void getData_firstCall_cacheMiss(CapturedOutput output) {
+        // When - first call (cache miss)
+        dataService.getData("key1");
+
+        // Then - method was invoked (logged)
+        assertThat(output.getOut()).contains("Loading data for key: key1");
+    }
+
+    @Test
+    void getData_secondCall_cacheHit(CapturedOutput output) {
+        // Given - first call to populate cache
+        dataService.getData("key1");
+
+        // Clear output
+        output.getOut(); // consume previous output
+
+        // When - second call (cache hit)
+        dataService.getData("key1");
+
+        // Then - method was NOT invoked again
+        long callCount = output.getOut().lines()
+                .filter(line -> line.contains("Loading data for key: key1"))
+                .count();
+        assertThat(callCount).isEqualTo(1); // Only from first call
+    }
+
+    @Test
+    void getData_cachedValue_retrievedFromCache() {
+        // Given
+        var expectedData = dataService.getData("key1");
+
+        // When
+        var cachedValue = cacheManager.getCache("dataCache").get("key1");
+
+        // Then
+        assertThat(cachedValue).isNotNull();
+        assertThat(cachedValue.get()).isEqualTo(expectedData);
+    }
+
+    @Test
+    void deleteData_existingKey_evictsFromCache() {
+        // Given - populate cache
+        dataService.getData("key1");
+        assertThat(cacheManager.getCache("dataCache").get("key1")).isNotNull();
+
+        // When
+        dataService.deleteData("key1");
+
+        // Then
+        assertThat(cacheManager.getCache("dataCache").get("key1")).isNull();
+    }
+
+    @Test
+    void updateData_existingKey_updatesCacheEntry() {
+        // Given - populate cache
+        dataService.getData("key1");
+
+        // When
+        var updatedData = new Data("key1", "updated-value");
+        dataService.updateData("key1", updatedData);
+
+        // Then
+        var cachedValue = cacheManager.getCache("dataCache").get("key1");
+        assertThat(cachedValue).isNotNull();
+        assertThat(((Data) cachedValue.get()).getValue()).isEqualTo("updated-value");
+    }
+
+    @Test
+    void clearCache_evictsAllEntries() {
+        // Given - populate cache with multiple entries
+        dataService.getData("key1");
+        dataService.getData("key2");
+        assertThat(cacheManager.getCache("dataCache").get("key1")).isNotNull();
+        assertThat(cacheManager.getCache("dataCache").get("key2")).isNotNull();
+
+        // When
+        dataService.clearAllData();
+
+        // Then
+        assertThat(cacheManager.getCache("dataCache").get("key1")).isNull();
+        assertThat(cacheManager.getCache("dataCache").get("key2")).isNull();
+    }
+}
+```
+
+### Key Points
+
+1. Use `@EnableCaching` to activate cache abstraction
+2. Use `@ImportAutoConfiguration(CacheAutoConfiguration.class)`
+3. Set `spring.cache.type=redis` in properties
+4. Use `OutputCaptureExtension` to verify method invocation
+5. Use `CacheManager` to inspect cache state
+6. Test all cache operations: `@Cacheable`, `@CacheEvict`, `@CachePut`
+7. Verify both cache miss (method called) and cache hit (method NOT called)

--- a/skills/generate-tests/rules/tests/java/integration/redis-pubsub-rules.md
+++ b/skills/generate-tests/rules/tests/java/integration/redis-pubsub-rules.md
@@ -1,0 +1,216 @@
+---
+title: Redis Pub/Sub Test Rules
+impact: HIGH
+impactDescription: ensures proper testing of Redis pub/sub messaging with containers
+tags: java, tests, integration, redis, pubsub, testcontainers, messaging
+---
+
+## Redis Pub/Sub Test Rules
+
+Use Testcontainers with GenericContainer for Redis pub/sub tests. Configure listener containers properly.
+
+### Rules
+
+- Use `@Testcontainers` with `GenericContainer` for Redis (image `"redis:7-alpine"` or latest)
+- Use `@SpringJUnitConfig` to load only the component under test and inline TestConfig
+- Use `@ImportAutoConfiguration(RedisAutoConfiguration.class)` to enable Redis infrastructure
+- Use `@DynamicPropertySource` to inject container connection properties (host, port)
+- Use `@DirtiesContext` to reset context after each test method
+- Declare `ChannelTopic` and `RedisMessageListenerContainer` beans in inline `@TestConfiguration`
+- Autowire `RedisTemplate<String, String>` for sending/receiving messages
+- For Consumer tests: use `RedisTemplate.convertAndSend()` to send test messages
+- For Producer tests: use Jedis subscriber or `RedisTemplate` for verification
+- Use Awaitility for async assertions
+- Set `spring.data.redis.host` and `spring.data.redis.port` via `@DynamicPropertySource`
+- Do NOT use `@SpringBootTest`
+- Do NOT use `@DataRedisTest` (it's for repositories, not Pub/Sub)
+- Always set `ConnectionFactory` on `RedisTemplate` and `RedisMessageListenerContainer` beans
+
+**Incorrect:**
+
+```java
+// Using @DataRedisTest for Pub/Sub - wrong!
+@DataRedisTest
+class NotificationPublisherIT {
+    // DataRedisTest is for repositories
+}
+
+// Using @SpringBootTest - too heavy
+@SpringBootTest
+class NotificationPublisherIT {
+    // ...
+}
+```
+
+**Correct:**
+
+```java
+import org.awaitility.Awaitility;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.autoconfigure.data.redis.RedisAutoConfiguration;
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.ChannelTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.DynamicPropertyRegistry;
+import org.springframework.test.context.DynamicPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringJUnitConfig;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.junit.jupiter.Container;
+import org.testcontainers.junit.jupiter.Testcontainers;
+import org.testcontainers.utility.DockerImageName;
+import redis.clients.jedis.Jedis;
+import redis.clients.jedis.JedisPubSub;
+
+import java.time.Duration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Testcontainers
+@SpringJUnitConfig(classes = {NotificationPublisher.class, NotificationPublisherIT.TestConfig.class})
+@ImportAutoConfiguration(RedisAutoConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class NotificationPublisherIT {
+
+    @Container
+    static final GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", redis::getFirstMappedPort);
+    }
+
+    @Autowired
+    private ChannelTopic notificationTopic;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    private NotificationPublisher notificationPublisher;
+
+    @Test
+    void publish_validMessage_sendsToChannel() {
+        // Given
+        String[] receivedMessage = new String[1];
+
+        Thread subscriberThread = new Thread(() -> {
+            try (Jedis jedis = new Jedis(redis.getHost(), redis.getFirstMappedPort())) {
+                jedis.subscribe(new JedisPubSub() {
+                    @Override
+                    public void onMessage(String channel, String message) {
+                        receivedMessage[0] = message;
+                        this.unsubscribe();
+                    }
+                }, notificationTopic.getTopic());
+            }
+        });
+        subscriberThread.start();
+
+        // Wait for subscriber to be ready
+        Awaitility.await().pollDelay(Duration.ofMillis(500)).until(() -> true);
+
+        // When
+        notificationPublisher.publish("test notification message");
+
+        // Then
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> assertThat(receivedMessage[0]).isEqualTo("test notification message"));
+    }
+
+    @TestConfiguration
+    static class TestConfig {
+
+        @Bean
+        public ChannelTopic notificationTopic() {
+            return new ChannelTopic("notifications");
+        }
+
+        @Bean
+        public RedisMessageListenerContainer redisMessageListenerContainer(
+                RedisConnectionFactory connectionFactory) {
+            RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+            container.setConnectionFactory(connectionFactory);
+            return container;
+        }
+    }
+}
+```
+
+### Consumer Test Template
+
+```java
+@Testcontainers
+@SpringJUnitConfig(classes = {NotificationConsumer.class, NotificationConsumerIT.TestConfig.class})
+@ImportAutoConfiguration(RedisAutoConfiguration.class)
+@DirtiesContext(classMode = DirtiesContext.ClassMode.AFTER_EACH_TEST_METHOD)
+class NotificationConsumerIT {
+
+    @Container
+    static final GenericContainer<?> redis = new GenericContainer<>(DockerImageName.parse("redis:7-alpine"))
+            .withExposedPorts(6379);
+
+    @DynamicPropertySource
+    static void redisProperties(DynamicPropertyRegistry registry) {
+        registry.add("spring.data.redis.host", redis::getHost);
+        registry.add("spring.data.redis.port", redis::getFirstMappedPort);
+    }
+
+    @Autowired
+    private ChannelTopic notificationTopic;
+
+    @Autowired
+    private RedisTemplate<String, String> redisTemplate;
+
+    @Autowired
+    private NotificationConsumer notificationConsumer;
+
+    @Test
+    void onMessage_validMessage_processesSuccessfully() {
+        // When
+        redisTemplate.convertAndSend(notificationTopic.getTopic(), "test message");
+
+        // Then
+        Awaitility.await()
+                .atMost(Duration.ofSeconds(10))
+                .untilAsserted(() -> {
+                    // Verify consumer behavior
+                    assertThat(true).isTrue(); // Replace with actual assertion
+                });
+    }
+
+    @TestConfiguration
+    static class TestConfig {
+
+        @Bean
+        public ChannelTopic notificationTopic() {
+            return new ChannelTopic("notifications");
+        }
+
+        @Bean
+        public RedisMessageListenerContainer redisMessageListenerContainer(
+                RedisConnectionFactory connectionFactory) {
+            RedisMessageListenerContainer container = new RedisMessageListenerContainer();
+            container.setConnectionFactory(connectionFactory);
+            return container;
+        }
+    }
+}
+```
+
+### Key Points
+
+1. Use `GenericContainer` with `redis:7-alpine` image
+2. Configure `ChannelTopic` and `RedisMessageListenerContainer` in `@TestConfiguration`
+3. Set `ConnectionFactory` on `RedisMessageListenerContainer`
+4. Use Jedis for producer verification (subscribing)
+5. Use `RedisTemplate.convertAndSend()` for consumer testing
+6. Use Awaitility for async assertions


### PR DESCRIPTION
## What

Adds `skills/generate-tests/rules/tests/java/integration/` with nine rules and wires them into `SKILL.md`:

| Rule | Covers |
|---|---|
| `jpa-repository-rules.md` | `@DataJpaTest` against a real DB via Testcontainers |
| `external-http-wiremock.md` | WireMock for HTTP clients instead of mocking the client |
| `kafka-consumer-rules.md` / `kafka-producer-rules.md` | `@EmbeddedKafka` and Testcontainers |
| `rabbitmq-rules.md` | `RabbitMQContainer` |
| `redis-pubsub-rules.md` / `redis-cache-rules.md` | Redis messaging and Spring Cache |
| `aws-rules.md` | S3, DynamoDB, SQS via LocalStack |
| `configuration-properties-rules.md` | `@ConfigurationProperties` binding and validation |

## Why

Step 4 of `generate-tests` routed repositories, messaging components, HTTP clients and config-properties classes to `domain-service-rules.md` and told the user that type-specific rules were not yet available. These are exactly the types that cannot be meaningfully tested with mocks, so the fallback produced weak tests.

The rules come from the internal `clear-solutions/tests-skills` repo, which is where the published skills originated.

## Notes for review

Three decisions worth a look:

1. **`controller-rules.md` was deliberately left out.** The internal set has an integration variant for controllers, but `java/unit/controller-test-rules.md` already covers `@WebMvcTest`, security annotations and validation, and does it with the current `@MockitoBean` rather than the deprecated `@MockBean`. Porting it would have left two conflicting controller rules in one skill.

2. **Scope.** The plugin is presented as unit-test tooling. These rules generate integration tests, so `SKILL.md` now instructs the agent to say so when it produces one. `plugin.json` / `marketplace.json` / README still say "unit tests" — deliberately untouched, as changing the plugin's public description is a separate call.

3. **`@SpringBootTest`.** `java-test-template.md` forbids it. Step 4 now states that the ban applies to unit tests and that integration rules override it for the types they cover.

`./scripts/validate-plugin.sh` passes.