### PR TITLE
ci: validate rule references on every pull request

### DIFF
--- a/.github/workflows/validate-plugin.yml
+++ b/.github/workflows/validate-plugin.yml
@@ -30,10 +30,10 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Set up Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v7
         with:
           node-version: '22'
 

--- a/.github/workflows/validate-rules.yml
+++ b/.github/workflows/validate-rules.yml
@@ -1,0 +1,27 @@
+name: Validate Rules
+
+# Deliberately unfiltered: this runs on every pull request, not only on ones
+# that touch skills/. A required status check that is skipped never reports,
+# and a pull request waiting on a check that will never arrive cannot merge.
+# The job is a checkout and a bash script — cheap enough to always run.
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  rules:
+    name: validate rule references
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Validate rule references
+        run: ./scripts/validate-rules.sh

--- a/.github/workflows/validate-rules.yml
+++ b/.github/workflows/validate-rules.yml
@@ -21,7 +21,7 @@ jobs:
 
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: Validate rule references
         run: ./scripts/validate-rules.sh

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -54,6 +54,44 @@ validation is entirely local.
 - Keep `skills/` at the repository root. Only `plugin.json` and
   `marketplace.json` belong inside `.claude-plugin/`.
 
+## Rule Validation
+
+A skill is only as good as the rules it actually loads, and every way that can
+break is silent at runtime: the agent reads `SKILL.md`, follows a reference to a
+rule that is not there, and generates tests without it. Nothing errors — the
+output just gets worse.
+
+**After adding, renaming, moving, or deleting anything under a skill's `rules/`,
+run:**
+
+```bash
+./scripts/validate-rules.sh
+```
+
+CI runs the same script in its own workflow
+(`.github/workflows/validate-rules.yml`), on **every** pull request rather than
+only ones touching `skills/`. Two reasons it is separate from plugin
+validation: it needs no Node and no CLI, so a broken upstream release cannot
+take it down; and it carries no path filter, so it always reports and is safe
+to require before merge. A required check that gets skipped never reports, and
+a pull request waiting on a check that will never arrive cannot merge.
+
+### What it checks, and why each check exists
+
+| Check | What it catches |
+|---|---|
+| Referenced rule files exist | A reference in `SKILL.md` (or `RULES-INDEX.md`) naming a file that is not on disk. References come in three valid shapes — `./rules/general/x.md` from the skill root, `general/x.md` from `rules/tests/`, and a bare `x.md` in prose — so a reference passes if any shape resolves. |
+| Every rule file is referenced | The reverse direction. A rule added to the tree but never named in `SKILL.md` is dead weight: nothing instructs the agent to read it. |
+| General rules are in sync | Each skill carries its own copy of the general rules, because a skill is installed standalone and has to be self-contained. Two copies can drift, and a drifted copy means the same request gets different rules depending on which skill the agent picked. |
+| Rule files sit in a known category | This distribution ships unit-test rules only. The check lists the categories that belong here (`general/`, `java/unit/`, `post-generation/`) rather than the ones that do not, so it also catches a category nobody has invented yet. |
+
+### Conventions that follow from this
+
+- A new rule takes two edits, not one: the file itself **and** an entry in the
+  relevant `SKILL.md`. The second check fails without it.
+- Edit general rules in both locations in the same commit. Fixing one copy and
+  leaving the other for later fails the third check.
+
 ## Creating a New Skill
 
 ### Directory Structure
@@ -108,6 +146,9 @@ skills/{skill-name}/rules/
   {language}/unit/
     {rule-name}.md
 ```
+
+Then list it in that skill's `SKILL.md` and run `./scripts/validate-rules.sh`.
+See [Rule Validation](#rule-validation) for what the checks enforce.
 
 ### Rule File Format
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -86,4 +86,5 @@ file is the single source of truth; do not duplicate its detail here.
 - Place language-specific rules in `rules/tests/{language}/unit/`
 - **Keep general rules in sync**: General rules exist in TWO locations (`generate-test-cases/rules/general/` and `generate-tests/rules/tests/general/`). When adding or updating a general rule, copy the change to both directories
 - When adding a new rule, also add it to the Rules Reference list in the relevant `SKILL.md` file(s)
+- **After any change under a skill's `rules/`, run `./scripts/validate-rules.sh`.** It enforces the two points above — a reference with no file, a file with no reference, and general rules that have drifted apart. CI runs it on every PR. See [AGENTS.md](AGENTS.md#rule-validation) for what each check catches; that file is the single source of truth, do not duplicate its detail here
 - All changes require a PR with CODEOWNER approval; direct pushes to `main` are disabled

--- a/scripts/validate-rules.sh
+++ b/scripts/validate-rules.sh
@@ -29,12 +29,34 @@ docs_for() {
   return 0
 }
 
+# Documents that are not rules. A SKILL.md may legitimately point at AGENTS.md
+# or README.md, and counting that as a rule reference turns a cross-reference
+# into a build failure.
+NOT_A_RULE='(^|/)(AGENTS|AGENTS-SNIPPET|CLAUDE|README|RULES-INDEX|HELP)\.md$'
+
+# Rule references in a document, one per line, paths kept as written.
+#
+# Both checks below read this, so they cannot disagree on what a reference is.
+# They used to: check 1 looked only at backticked tokens while check 2 matched
+# the raw document text, so a bare prose mention counted as a reference for one
+# and was invisible to the other. Backticks are a typographic choice, not a
+# reference, so neither form is privileged here.
+refs_in() {
+  grep -oE '[A-Za-z0-9._/-]+\.md' "$1" \
+    | sed 's|^\./||' \
+    | grep -vE "${NOT_A_RULE}" \
+    | sort -u \
+    || true
+}
+
 # --- 1. Every referenced rule file exists ------------------------------------
 # References appear in three shapes across the skills, all of them valid:
 #   ./rules/general/x.md   (from the skill root)
 #   general/x.md           (from rules/tests/)
 #   x.md                   (bare, in prose: "see compilation-verification.md")
-# A reference resolves if any shape lands on a real file, so try each.
+# A reference resolves if any shape lands on a real file, so try each. The path
+# is checked as written: flattening it to a basename would let a reference name
+# the wrong directory and still pass.
 echo "==> Referenced rule files exist"
 for skill in skills/*/; do
   skill="${skill%/}"
@@ -53,7 +75,7 @@ for skill in skills/*/; do
         *) [ -n "$(find "${skill}/rules" -name "${rel}" -print -quit 2>/dev/null)" ] && continue ;;
       esac
       fail "✘ ${doc} references a rule that does not exist: ${ref}"
-    done < <(grep -o '`[^`]*\.md`' "${doc}" | tr -d '`' | grep -v '^RULES-INDEX\.md$' | sort -u)
+    done < <(refs_in "${doc}")
   done
 done
 
@@ -64,15 +86,15 @@ echo "==> Every rule file is referenced"
 for skill in skills/*/; do
   skill="${skill%/}"
   [ -d "${skill}/rules" ] || continue
-  # Read the docs one at a time. `cat $(docs_for ...)` reached `cat` with no
-  # operands for a skill that has rules/ but neither document, and `cat` with no
-  # operands reads stdin — which hangs the run against a terminal.
-  refs="$(docs_for "${skill}" | while IFS= read -r doc; do cat "${doc}" 2>/dev/null || true; done)"
+  # Compare on basenames: check 1 owns whether a reference resolves to the right
+  # path, this one only asks whether the file is named at all.
+  refs="$(for doc in $(docs_for "${skill}"); do refs_in "${doc}"; done | sed 's|.*/||' | sort -u)"
   while IFS= read -r rule; do
-    case "${refs}" in
-      *"$(basename "${rule}")"*) ;;
-      *) fail "✘ no SKILL.md or RULES-INDEX.md references ${rule}" ;;
-    esac
+    # Exact whole-line match. A substring test passed any rule whose basename
+    # was contained in another reference — principles.md inside
+    # general-principles.md — which is the silence this check exists to end.
+    printf '%s\n' "${refs}" | grep -qxF "$(basename "${rule}")" \
+      || fail "✘ no SKILL.md or RULES-INDEX.md references ${rule}"
   done < <(find "${skill}/rules" -name '*.md' ! -name 'RULES-INDEX.md' | sort)
 done
 

--- a/scripts/validate-rules.sh
+++ b/scripts/validate-rules.sh
@@ -1,0 +1,109 @@
+#!/usr/bin/env bash
+#
+# Validates the rule files that back each skill.
+#
+# A skill is only as good as the rules it actually loads. Every failure below is
+# silent at runtime: the agent reads SKILL.md, follows a reference to a rule that
+# is not there, and generates tests without it. Nothing errors, the output just
+# gets worse. These checks make that visible at review time instead.
+#
+# Usage: ./scripts/validate-rules.sh
+# Requires: bash, diff, find, grep. No credentials, no network.
+
+set -euo pipefail
+
+ROOT="$(cd "$(dirname "${BASH_SOURCE[0]}")/.." && pwd)"
+cd "${ROOT}"
+
+FAILURES="$(mktemp)"
+trap 'rm -f "${FAILURES}"' EXIT
+
+fail() { printf '%s\n' "$*" >>"${FAILURES}"; }
+
+# Documents that point an agent at a rule file.
+docs_for() { ls "$1/SKILL.md" "$1/rules/RULES-INDEX.md" 2>/dev/null; }
+
+# --- 1. Every referenced rule file exists ------------------------------------
+# References appear in three shapes across the skills, all of them valid:
+#   ./rules/general/x.md   (from the skill root)
+#   general/x.md           (from rules/tests/)
+#   x.md                   (bare, in prose: "see compilation-verification.md")
+# A reference resolves if any shape lands on a real file, so try each.
+echo "==> Referenced rule files exist"
+for skill in skills/*/; do
+  skill="${skill%/}"
+  for doc in $(docs_for "${skill}"); do
+    while IFS= read -r ref; do
+      [ -n "${ref}" ] || continue
+      rel="${ref#./}"
+      if [ -f "${skill}/${rel}" ] \
+        || [ -f "${skill}/rules/${rel}" ] \
+        || [ -f "${skill}/rules/tests/${rel}" ]; then
+        continue
+      fi
+      # A bare basename may live anywhere under this skill's rules/.
+      case "${rel}" in
+        */*) ;;
+        *) [ -n "$(find "${skill}/rules" -name "${rel}" -print -quit 2>/dev/null)" ] && continue ;;
+      esac
+      fail "✘ ${doc} references a rule that does not exist: ${ref}"
+    done < <(grep -o '`[^`]*\.md`' "${doc}" | tr -d '`' | grep -v '^RULES-INDEX\.md$' | sort -u)
+  done
+done
+
+# --- 2. No rule file is left unreferenced -----------------------------------
+# The reverse direction of check 1. A rule added to the tree but never named in
+# SKILL.md is dead weight: the agent has no instruction to read it.
+echo "==> Every rule file is referenced"
+for skill in skills/*/; do
+  skill="${skill%/}"
+  [ -d "${skill}/rules" ] || continue
+  refs="$(cat $(docs_for "${skill}") 2>/dev/null || true)"
+  while IFS= read -r rule; do
+    case "${refs}" in
+      *"$(basename "${rule}")"*) ;;
+      *) fail "✘ no SKILL.md or RULES-INDEX.md references ${rule}" ;;
+    esac
+  done < <(find "${skill}/rules" -name '*.md' ! -name 'RULES-INDEX.md' | sort)
+done
+
+# --- 3. General rules stay identical across skills --------------------------
+# Both skills carry their own copy of the general rules, because each skill is
+# installed standalone and has to be self-contained. Two copies means they can
+# drift, and a drifted copy means the same request gets different rules
+# depending on which skill the agent picked.
+echo "==> General rules are in sync between skills"
+GEN_A="skills/generate-tests/rules/tests/general"
+GEN_B="skills/generate-test-cases/rules/general"
+if [ -d "${GEN_A}" ] && [ -d "${GEN_B}" ]; then
+  if ! diff -r "${GEN_A}" "${GEN_B}" >/dev/null 2>&1; then
+    fail "✘ general rules differ between the two skills:"
+    while IFS= read -r line; do fail "    ${line}"; done \
+      < <(diff -rq "${GEN_A}" "${GEN_B}" 2>&1 || true)
+  fi
+else
+  fail "✘ expected general rules in ${GEN_A} and ${GEN_B}"
+fi
+
+# --- 4. Rule files sit in a known category ----------------------------------
+# This distribution ships unit-test rules only. Listing the categories that
+# belong here, rather than the ones that do not, also catches a category nobody
+# has invented yet.
+echo "==> Rule files sit in a known category"
+ALLOWED_CATEGORIES='^(general|java/unit|post-generation)/[^/]+\.md$'
+while IFS= read -r rule; do
+  rel="${rule#*/rules/}"
+  rel="${rel#tests/}"
+  printf '%s\n' "${rel}" | grep -qE "${ALLOWED_CATEGORIES}" \
+    || fail "✘ rule is outside this distribution's categories: ${rule}"
+done < <(find skills -path '*/rules/*' -name '*.md' ! -name 'RULES-INDEX.md' | sort)
+
+# --- Report ------------------------------------------------------------------
+echo
+if [ -s "${FAILURES}" ]; then
+  cat "${FAILURES}"
+  echo
+  echo "✘ Rule validation failed"
+  exit 1
+fi
+echo "✔ All rule validation passed"

--- a/scripts/validate-rules.sh
+++ b/scripts/validate-rules.sh
@@ -20,8 +20,14 @@ trap 'rm -f "${FAILURES}"' EXIT
 
 fail() { printf '%s\n' "$*" >>"${FAILURES}"; }
 
-# Documents that point an agent at a rule file.
-docs_for() { ls "$1/SKILL.md" "$1/rules/RULES-INDEX.md" 2>/dev/null; }
+# Documents that point an agent at a rule file. Prints only the ones that exist,
+# one per line, and always succeeds: `ls` with a missing operand exits non-zero,
+# which made every caller depend on where `set -e` does and does not look.
+docs_for() {
+  [ -f "$1/SKILL.md" ] && printf '%s\n' "$1/SKILL.md"
+  [ -f "$1/rules/RULES-INDEX.md" ] && printf '%s\n' "$1/rules/RULES-INDEX.md"
+  return 0
+}
 
 # --- 1. Every referenced rule file exists ------------------------------------
 # References appear in three shapes across the skills, all of them valid:
@@ -58,7 +64,10 @@ echo "==> Every rule file is referenced"
 for skill in skills/*/; do
   skill="${skill%/}"
   [ -d "${skill}/rules" ] || continue
-  refs="$(cat $(docs_for "${skill}") 2>/dev/null || true)"
+  # Read the docs one at a time. `cat $(docs_for ...)` reached `cat` with no
+  # operands for a skill that has rules/ but neither document, and `cat` with no
+  # operands reads stdin — which hangs the run against a terminal.
+  refs="$(docs_for "${skill}" | while IFS= read -r doc; do cat "${doc}" 2>/dev/null || true; done)"
   while IFS= read -r rule; do
     case "${refs}" in
       *"$(basename "${rule}")"*) ;;


### PR DESCRIPTION
## Why

A skill is only as good as the rules it actually loads, and every way that wiring can break is **silent at runtime**: the agent reads `SKILL.md`, follows a reference to a rule that is not on disk, and generates tests without it. Nothing errors — the output just gets quietly worse.

Nothing in CI looks at the rules today. `validate-plugin.yml` only checks the manifests.

## What

`scripts/validate-rules.sh`, four checks:

| Check | What it catches |
|---|---|
| Referenced rule files exist | A reference in `SKILL.md` naming a file that is not there. Handles all three reference shapes in use: `./rules/general/x.md`, `general/x.md`, and a bare `x.md` in prose |
| Every rule file is referenced | The reverse. A rule in the tree that no `SKILL.md` names is dead weight — nothing tells the agent to read it |
| General rules are in sync | The two copies (`generate-tests/rules/tests/general/` and `generate-test-cases/rules/general/`) must stay identical, or the same request gets different rules depending on which skill was picked |
| Rule files sit in a known category | Allowlist of `general/`, `java/unit/`, `post-generation/`. Listing what belongs here rather than what does not also catches a category nobody has invented yet |

## Verification

Not just "it goes green". Each fault was injected into a throwaway copy, one at a time:

| Injected fault | Result |
|---|---|
| Reference to a nonexistent file | fails ✔ |
| Rule file deleted, reference left behind | fails ✔ (caught by two checks) |
| Rule on disk that nothing references | fails ✔ |
| General rules edited in one copy only | fails ✔ |
| Rule placed in an unknown category | fails ✔ |
| Untouched copy (control) | passes ✔ |

Current tree: 36 references, 36 resolved. `./scripts/validate-plugin.sh` still passes.

## Why a separate workflow

`validate-plugin.yml` is **not touched** — this branch is purely additive, 0 deletions.

The new checks live in their own `validate-rules.yml` with **no path filter**, for two reasons:

1. **It can be a required status check.** The last commit on `main` produced zero check runs, because it was docs-only and the path filters skipped it. A required check that gets skipped never reports, and a PR waiting on a check that will never arrive cannot merge.
2. **No Node, no CLI.** Plugin validation deliberately installs an unpinned `claude`, so an upstream release can break that job by design. Keeping the rule checks separate means that cannot take them down.

## Follow-up

Once this is green, `validate rule references` is the check worth adding to the `SecureMainBranch` ruleset as required. `claude plugin validate --strict` is a poor fit for that — it is path-filtered and depends on an unpinned CLI.